### PR TITLE
chore: Remove trivial sync differences for istio & spark-operator

### DIFF
--- a/applications/spark/spark-operator/base/resources.yaml
+++ b/applications/spark/spark-operator/base/resources.yaml
@@ -25716,6 +25716,7 @@ metadata:
     app.kubernetes.io/version: "2.5.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
+
 ---
 # Source: spark-operator/templates/webhook/serviceaccount.yaml
 apiVersion: v1
@@ -25731,6 +25732,7 @@ metadata:
     app.kubernetes.io/version: "2.5.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: webhook
+
 ---
 # Source: spark-operator/templates/controller/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26057,6 +26059,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: spark-operator-controller
+
 ---
 # Source: spark-operator/templates/webhook/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26079,6 +26082,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: spark-operator-webhook
+
 ---
 # Source: spark-operator/templates/webhook/service.yaml
 apiVersion: v1
@@ -26101,6 +26105,7 @@ spec:
   - port: 9443
     targetPort: "webhook"
     name: webhook
+
 ---
 # Source: spark-operator/templates/controller/deployment.yaml
 apiVersion: apps/v1
@@ -26152,7 +26157,7 @@ spec:
         - --metrics-labels=app_type
         - --metrics-job-submit-latency-buckets=0.5,1,2,4,8,16,32,64,128,256
         - --metrics-job-start-latency-buckets=30,60,90,120,150,180,210,240,270,300
-
+        
         - --leader-election=true
         - --leader-election-lock-name=spark-operator-controller-lock
         - --leader-election-lock-namespace=kubeflow
@@ -26203,6 +26208,7 @@ spec:
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 185
+
 ---
 # Source: spark-operator/templates/webhook/deployment.yaml
 apiVersion: apps/v1
@@ -26255,7 +26261,7 @@ spec:
         - --metrics-labels=app_type
         - --kube-api-qps=20
         - --kube-api-burst=30
-
+        
         - --leader-election=true
         - --leader-election-lock-name=spark-operator-webhook-lock
         - --leader-election-lock-namespace=kubeflow
@@ -26297,6 +26303,7 @@ spec:
       automountServiceAccountToken: true
       securityContext:
         fsGroup: 185
+
 ---
 # Source: spark-operator/templates/webhook/mutatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -26378,6 +26385,7 @@ webhooks:
     resources: ["sparkconnects"]
     operations: ["CREATE", "UPDATE"]
   timeoutSeconds: 10
+
 ---
 # Source: spark-operator/templates/webhook/validatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/common/istio/cluster-local-gateway/base/cluster-local-gateway.yaml
+++ b/common/istio/cluster-local-gateway/base/cluster-local-gateway.yaml
@@ -130,7 +130,7 @@ spec:
         - name: ISTIO_META_WORKLOAD_NAME
           value: cluster-local-gateway
         - name: ISTIO_META_OWNER
-          value:
+          value: 
             kubernetes://apis/apps/v1/namespaces/istio-system/deployments/cluster-local-gateway
         - name: ISTIO_META_MESH_ID
           value: cluster.local

--- a/common/istio/istio-crds/base/crd.yaml
+++ b/common/istio/istio-crds/base/crd.yaml
@@ -64,7 +64,7 @@ spec:
                 - CUSTOM
                 type: string
               provider:
-                description: Specifies detailed configuration of the CUSTOM
+                description: Specifies detailed configuration of the CUSTOM 
                   action.
                 properties:
                   name:
@@ -80,7 +80,7 @@ spec:
                       items:
                         properties:
                           source:
-                            description: Source specifies the source of a
+                            description: Source specifies the source of a 
                               request.
                             properties:
                               ipBlocks:
@@ -159,7 +159,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: Cannot set serviceAccounts with
+                            - message: Cannot set serviceAccounts with 
                                 namespaces or principals
                               rule: |-
                                 (has(self.serviceAccounts) || has(self.notServiceAccounts)) ? (!has(self.principals) &&
@@ -172,7 +172,7 @@ spec:
                       items:
                         properties:
                           operation:
-                            description: Operation specifies the operation of a
+                            description: Operation specifies the operation of a 
                               request.
                             properties:
                               hosts:
@@ -267,7 +267,7 @@ spec:
                   group:
                     description: group is the group of the target resource.
                     maxLength: 253
-                    pattern:
+                    pattern: 
                       ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
@@ -285,7 +285,7 @@ spec:
                     description: namespace is the namespace of the referent.
                     type: string
                     x-kubernetes-validations:
-                    - message: cross namespace referencing is not currently
+                    - message: cross namespace referencing is not currently 
                         supported
                       rule: self.size() == 0
                 required:
@@ -299,7 +299,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -317,7 +317,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -347,18 +347,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -397,12 +397,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -455,7 +455,7 @@ spec:
                 - CUSTOM
                 type: string
               provider:
-                description: Specifies detailed configuration of the CUSTOM
+                description: Specifies detailed configuration of the CUSTOM 
                   action.
                 properties:
                   name:
@@ -471,7 +471,7 @@ spec:
                       items:
                         properties:
                           source:
-                            description: Source specifies the source of a
+                            description: Source specifies the source of a 
                               request.
                             properties:
                               ipBlocks:
@@ -550,7 +550,7 @@ spec:
                                 type: array
                             type: object
                             x-kubernetes-validations:
-                            - message: Cannot set serviceAccounts with
+                            - message: Cannot set serviceAccounts with 
                                 namespaces or principals
                               rule: |-
                                 (has(self.serviceAccounts) || has(self.notServiceAccounts)) ? (!has(self.principals) &&
@@ -563,7 +563,7 @@ spec:
                       items:
                         properties:
                           operation:
-                            description: Operation specifies the operation of a
+                            description: Operation specifies the operation of a 
                               request.
                             properties:
                               hosts:
@@ -658,7 +658,7 @@ spec:
                   group:
                     description: group is the group of the target resource.
                     maxLength: 253
-                    pattern:
+                    pattern: 
                       ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
@@ -676,7 +676,7 @@ spec:
                     description: namespace is the namespace of the referent.
                     type: string
                     x-kubernetes-validations:
-                    - message: cross namespace referencing is not currently
+                    - message: cross namespace referencing is not currently 
                         supported
                       rule: self.size() == 0
                 required:
@@ -690,7 +690,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -708,7 +708,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -738,18 +738,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -788,12 +788,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -840,11 +840,11 @@ spec:
       name: Host
       type: string
     - description: CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in
-        happens-before order across separate operations. Clients may not set
-        this value. It is represented in RFC3339 form and is in UTC. Populated
-        by the system. Read-only. Null for lists. For more information, see
-        [Kubernetes API
+        when this object was created. It is not guaranteed to be set in 
+        happens-before order across separate operations. Clients may not set 
+        this value. It is represented in RFC3339 form and is in UTC. Populated 
+        by the system. Read-only. Null for lists. For more information, see 
+        [Kubernetes API 
         Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -867,7 +867,7 @@ spec:
                 description: The name of a service from the service registry.
                 type: string
               subsets:
-                description: One or more named sets that represent individual
+                description: One or more named sets that represent individual 
                   versions of a service.
                 items:
                   properties:
@@ -899,8 +899,8 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of requests that
-                                    will be queued while waiting for a ready
+                                  description: Maximum number of requests that 
+                                    will be queued while waiting for a ready 
                                     connection pool connection.
                                   format: int32
                                   type: integer
@@ -910,97 +910,97 @@ spec:
                                   format: int32
                                   type: integer
                                 idleTimeout:
-                                  description: The idle timeout for upstream
+                                  description: The idle timeout for upstream 
                                     connection pool connections.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConcurrentStreams:
-                                  description: The maximum number of concurrent
-                                    streams allowed for a peer on one HTTP/2
+                                  description: The maximum number of concurrent 
+                                    streams allowed for a peer on one HTTP/2 
                                     connection.
                                   format: int32
                                   type: integer
                                 maxRequestsPerConnection:
-                                  description: Maximum number of requests per
+                                  description: Maximum number of requests per 
                                     connection to a backend.
                                   format: int32
                                   type: integer
                                 maxRetries:
-                                  description: Maximum number of retries that
+                                  description: Maximum number of retries that 
                                     can be outstanding to all hosts in a cluster
                                     at a given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
-                                  description: If set to true, client protocol
-                                    will be preserved while initiating
+                                  description: If set to true, client protocol 
+                                    will be preserved while initiating 
                                     connection to backend.
                                   type: boolean
                               type: object
                             tcp:
-                              description: Settings common to both HTTP and TCP
+                              description: Settings common to both HTTP and TCP 
                                 upstream connections.
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 idleTimeout:
-                                  description: The idle timeout for TCP
+                                  description: The idle timeout for TCP 
                                     connections.
                                   type: string
                                 maxConnectionDuration:
-                                  description: The maximum duration of a
+                                  description: The maximum duration of a 
                                     connection.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConnections:
-                                  description: Maximum number of HTTP1 /TCP
+                                  description: Maximum number of HTTP1 /TCP 
                                     connections to a destination host.
                                   format: int32
                                   type: integer
                                 tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on
+                                  description: If set then set SO_KEEPALIVE on 
                                     the socket to enable TCP Keepalives.
                                   properties:
                                     interval:
-                                      description: The time duration between
+                                      description: The time duration between 
                                         keep-alive probes.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                     probes:
-                                      description: Maximum number of keepalive
-                                        probes to send without response before
+                                      description: Maximum number of keepalive 
+                                        probes to send without response before 
                                         deciding the connection is dead.
                                       maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                     time:
-                                      description: The time duration a
-                                        connection needs to be idle before
+                                      description: The time duration a 
+                                        connection needs to be idle before 
                                         keep-alive probes start being sent.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                   type: object
                               type: object
                           type: object
                         loadBalancer:
-                          description: Settings controlling the load balancer
+                          description: Settings controlling the load balancer 
                             algorithms.
                           oneOf:
                           - not:
@@ -1056,11 +1056,11 @@ spec:
                                       items:
                                         properties:
                                           name:
-                                            description: The name of the cookie
+                                            description: The name of the cookie 
                                               attribute.
                                             type: string
                                           value:
-                                            description: The optional value of
+                                            description: The optional value of 
                                               the cookie attribute.
                                             type: string
                                         required:
@@ -1080,20 +1080,20 @@ spec:
                                   - name
                                   type: object
                                 httpHeaderName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     header.
                                   type: string
                                 httpQueryParameterName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     query parameter.
                                   type: string
                                 maglev:
-                                  description: The Maglev load balancer
-                                    implements consistent hashing to backend
+                                  description: The Maglev load balancer 
+                                    implements consistent hashing to backend 
                                     hosts.
                                   properties:
                                     tableSize:
-                                      description: The table size for Maglev
+                                      description: The table size for Maglev 
                                         hashing.
                                       minimum: 0
                                       type: integer
@@ -1103,8 +1103,8 @@ spec:
                                   minimum: 0
                                   type: integer
                                 ringHash:
-                                  description: The ring/modulo hash load
-                                    balancer implements consistent hashing to
+                                  description: The ring/modulo hash load 
+                                    balancer implements consistent hashing to 
                                     backend hosts.
                                   properties:
                                     minimumRingSize:
@@ -1114,7 +1114,7 @@ spec:
                                       type: integer
                                   type: object
                                 useSourceIp:
-                                  description: Hash based on the source IP
+                                  description: Hash based on the source IP 
                                     address.
                                   type: boolean
                               type: object
@@ -1126,7 +1126,7 @@ spec:
                                   items:
                                     properties:
                                       from:
-                                        description: Originating locality, '/'
+                                        description: Originating locality, '/' 
                                           separated, e.g.
                                         type: string
                                       to:
@@ -1134,7 +1134,7 @@ spec:
                                           maximum: 4294967295
                                           minimum: 0
                                           type: integer
-                                        description: Map of upstream localities
+                                        description: Map of upstream localities 
                                           to traffic distribution weights.
                                         type: object
                                     type: object
@@ -1152,16 +1152,16 @@ spec:
                                         description: Originating region.
                                         type: string
                                       to:
-                                        description: Destination region the
-                                          traffic will fail over to when
+                                        description: Destination region the 
+                                          traffic will fail over to when 
                                           endpoints in the 'from' region becomes
                                           unhealthy.
                                         type: string
                                     type: object
                                   type: array
                                 failoverPriority:
-                                  description: failoverPriority is an ordered
-                                    list of labels used to sort endpoints to do
+                                  description: failoverPriority is an ordered 
+                                    list of labels used to sort endpoints to do 
                                     priority based load balancing.
                                   items:
                                     type: string
@@ -1181,12 +1181,12 @@ spec:
                               - LEAST_REQUEST
                               type: string
                             warmup:
-                              description: Represents the warmup configuration
+                              description: Represents the warmup configuration 
                                 of Service.
                               properties:
                                 aggression:
                                   description: This parameter controls the speed
-                                    of traffic increase over the warmup
+                                    of traffic increase over the warmup 
                                     duration.
                                   format: double
                                   minimum: 0
@@ -1195,7 +1195,7 @@ spec:
                                 duration:
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 minimumPercent:
@@ -1211,7 +1211,7 @@ spec:
                               description: 'Deprecated: use `warmup` instead.'
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                           type: object
@@ -1221,7 +1221,7 @@ spec:
                               description: Minimum ejection duration.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             consecutive5xxErrors:
@@ -1235,47 +1235,47 @@ spec:
                               format: int32
                               type: integer
                             consecutiveGatewayErrors:
-                              description: Number of gateway errors before a
+                              description: Number of gateway errors before a 
                                 host is ejected from the connection pool.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally
+                              description: The number of consecutive locally 
                                 originated failures before ejection occurs.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             interval:
-                              description: Time interval between ejection sweep
+                              description: Time interval between ejection sweep 
                                 analysis.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxEjectionPercent:
-                              description: Maximum % of hosts in the load
+                              description: Maximum % of hosts in the load 
                                 balancing pool for the upstream service that can
                                 be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
-                              description: Outlier detection will be enabled as
-                                long as the associated load balancing pool has
-                                at least `minHealthPercent` hosts in healthy
+                              description: Outlier detection will be enabled as 
+                                long as the associated load balancing pool has 
+                                at least `minHealthPercent` hosts in healthy 
                                 mode.
                               format: int32
                               type: integer
                             splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish
+                              description: Determines whether to distinguish 
                                 local origin failures from external errors.
                               type: boolean
                           type: object
                         portLevelSettings:
-                          description: Traffic policies specific to individual
+                          description: Traffic policies specific to individual 
                             ports.
                           items:
                             properties:
@@ -1295,117 +1295,117 @@ spec:
                                         - UPGRADE
                                         type: string
                                       http1MaxPendingRequests:
-                                        description: Maximum number of requests
-                                          that will be queued while waiting for
+                                        description: Maximum number of requests 
+                                          that will be queued while waiting for 
                                           a ready connection pool connection.
                                         format: int32
                                         type: integer
                                       http2MaxRequests:
-                                        description: Maximum number of active
+                                        description: Maximum number of active 
                                           requests to a destination.
                                         format: int32
                                         type: integer
                                       idleTimeout:
-                                        description: The idle timeout for
+                                        description: The idle timeout for 
                                           upstream connection pool connections.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       maxConcurrentStreams:
-                                        description: The maximum number of
-                                          concurrent streams allowed for a peer
+                                        description: The maximum number of 
+                                          concurrent streams allowed for a peer 
                                           on one HTTP/2 connection.
                                         format: int32
                                         type: integer
                                       maxRequestsPerConnection:
-                                        description: Maximum number of requests
+                                        description: Maximum number of requests 
                                           per connection to a backend.
                                         format: int32
                                         type: integer
                                       maxRetries:
-                                        description: Maximum number of retries
-                                          that can be outstanding to all hosts
+                                        description: Maximum number of retries 
+                                          that can be outstanding to all hosts 
                                           in a cluster at a given time.
                                         format: int32
                                         type: integer
                                       useClientProtocol:
-                                        description: If set to true, client
-                                          protocol will be preserved while
+                                        description: If set to true, client 
+                                          protocol will be preserved while 
                                           initiating connection to backend.
                                         type: boolean
                                     type: object
                                   tcp:
-                                    description: Settings common to both HTTP
+                                    description: Settings common to both HTTP 
                                       and TCP upstream connections.
                                     properties:
                                       connectTimeout:
                                         description: TCP connection timeout.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       idleTimeout:
-                                        description: The idle timeout for TCP
+                                        description: The idle timeout for TCP 
                                           connections.
                                         type: string
                                       maxConnectionDuration:
-                                        description: The maximum duration of a
+                                        description: The maximum duration of a 
                                           connection.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       maxConnections:
-                                        description: Maximum number of HTTP1
-                                          /TCP connections to a destination
+                                        description: Maximum number of HTTP1 
+                                          /TCP connections to a destination 
                                           host.
                                         format: int32
                                         type: integer
                                       tcpKeepalive:
-                                        description: If set then set
-                                          SO_KEEPALIVE on the socket to enable
+                                        description: If set then set 
+                                          SO_KEEPALIVE on the socket to enable 
                                           TCP Keepalives.
                                         properties:
                                           interval:
-                                            description: The time duration
+                                            description: The time duration 
                                               between keep-alive probes.
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: must be a valid duration
+                                            - message: must be a valid duration 
                                                 greater than 1ms
-                                              rule: duration(self) >=
+                                              rule: duration(self) >= 
                                                 duration('1ms')
                                           probes:
-                                            description: Maximum number of
-                                              keepalive probes to send without
-                                              response before deciding the
+                                            description: Maximum number of 
+                                              keepalive probes to send without 
+                                              response before deciding the 
                                               connection is dead.
                                             maximum: 4294967295
                                             minimum: 0
                                             type: integer
                                           time:
-                                            description: The time duration a
+                                            description: The time duration a 
                                               connection needs to be idle before
-                                              keep-alive probes start being
+                                              keep-alive probes start being 
                                               sent.
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: must be a valid duration
+                                            - message: must be a valid duration 
                                                 greater than 1ms
-                                              rule: duration(self) >=
+                                              rule: duration(self) >= 
                                                 duration('1ms')
                                         type: object
                                     type: object
                                 type: object
                               loadBalancer:
-                                description: Settings controlling the load
+                                description: Settings controlling the load 
                                   balancer algorithms.
                                 oneOf:
                                 - not:
@@ -1456,17 +1456,17 @@ spec:
                                         description: Hash based on HTTP cookie.
                                         properties:
                                           attributes:
-                                            description: Additional attributes
+                                            description: Additional attributes 
                                               for the cookie.
                                             items:
                                               properties:
                                                 name:
-                                                  description: The name of the
+                                                  description: The name of the 
                                                     cookie attribute.
                                                   type: string
                                                 value:
-                                                  description: The optional
-                                                    value of the cookie
+                                                  description: The optional 
+                                                    value of the cookie 
                                                     attribute.
                                                   type: string
                                               required:
@@ -1477,7 +1477,7 @@ spec:
                                             description: Name of the cookie.
                                             type: string
                                           path:
-                                            description: Path to set for the
+                                            description: Path to set for the 
                                               cookie.
                                             type: string
                                           ttl:
@@ -1487,20 +1487,20 @@ spec:
                                         - name
                                         type: object
                                       httpHeaderName:
-                                        description: Hash based on a specific
+                                        description: Hash based on a specific 
                                           HTTP header.
                                         type: string
                                       httpQueryParameterName:
-                                        description: Hash based on a specific
+                                        description: Hash based on a specific 
                                           HTTP query parameter.
                                         type: string
                                       maglev:
-                                        description: The Maglev load balancer
-                                          implements consistent hashing to
+                                        description: The Maglev load balancer 
+                                          implements consistent hashing to 
                                           backend hosts.
                                         properties:
                                           tableSize:
-                                            description: The table size for
+                                            description: The table size for 
                                               Maglev hashing.
                                             minimum: 0
                                             type: integer
@@ -1510,13 +1510,13 @@ spec:
                                         minimum: 0
                                         type: integer
                                       ringHash:
-                                        description: The ring/modulo hash load
+                                        description: The ring/modulo hash load 
                                           balancer implements consistent hashing
                                           to backend hosts.
                                         properties:
                                           minimumRingSize:
-                                            description: The minimum number of
-                                              virtual nodes to use for the hash
+                                            description: The minimum number of 
+                                              virtual nodes to use for the hash 
                                               ring.
                                             minimum: 0
                                             type: integer
@@ -1542,14 +1542,14 @@ spec:
                                                 maximum: 4294967295
                                                 minimum: 0
                                                 type: integer
-                                              description: Map of upstream
-                                                localities to traffic
+                                              description: Map of upstream 
+                                                localities to traffic 
                                                 distribution weights.
                                               type: object
                                           type: object
                                         type: array
                                       enabled:
-                                        description: Enable locality load
+                                        description: Enable locality load 
                                           balancing.
                                         nullable: true
                                         type: boolean
@@ -1562,17 +1562,17 @@ spec:
                                               description: Originating region.
                                               type: string
                                             to:
-                                              description: Destination region
-                                                the traffic will fail over to
-                                                when endpoints in the 'from'
+                                              description: Destination region 
+                                                the traffic will fail over to 
+                                                when endpoints in the 'from' 
                                                 region becomes unhealthy.
                                               type: string
                                           type: object
                                         type: array
                                       failoverPriority:
-                                        description: failoverPriority is an
-                                          ordered list of labels used to sort
-                                          endpoints to do priority based load
+                                        description: failoverPriority is an 
+                                          ordered list of labels used to sort 
+                                          endpoints to do priority based load 
                                           balancing.
                                         items:
                                           type: string
@@ -1592,12 +1592,12 @@ spec:
                                     - LEAST_REQUEST
                                     type: string
                                   warmup:
-                                    description: Represents the warmup
+                                    description: Represents the warmup 
                                       configuration of Service.
                                     properties:
                                       aggression:
                                         description: This parameter controls the
-                                          speed of traffic increase over the
+                                          speed of traffic increase over the 
                                           warmup duration.
                                         format: double
                                         minimum: 0
@@ -1606,9 +1606,9 @@ spec:
                                       duration:
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       minimumPercent:
                                         format: double
@@ -1623,7 +1623,7 @@ spec:
                                     description: 'Deprecated: use `warmup` instead.'
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                 type: object
@@ -1633,11 +1633,11 @@ spec:
                                     description: Minimum ejection duration.
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                   consecutive5xxErrors:
-                                    description: Number of 5xx errors before a
+                                    description: Number of 5xx errors before a 
                                       host is ejected from the connection pool.
                                     maximum: 4294967295
                                     minimum: 0
@@ -1648,50 +1648,50 @@ spec:
                                     type: integer
                                   consecutiveGatewayErrors:
                                     description: Number of gateway errors before
-                                      a host is ejected from the connection
+                                      a host is ejected from the connection 
                                       pool.
                                     maximum: 4294967295
                                     minimum: 0
                                     nullable: true
                                     type: integer
                                   consecutiveLocalOriginFailures:
-                                    description: The number of consecutive
-                                      locally originated failures before
+                                    description: The number of consecutive 
+                                      locally originated failures before 
                                       ejection occurs.
                                     maximum: 4294967295
                                     minimum: 0
                                     nullable: true
                                     type: integer
                                   interval:
-                                    description: Time interval between ejection
+                                    description: Time interval between ejection 
                                       sweep analysis.
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                   maxEjectionPercent:
-                                    description: Maximum % of hosts in the load
-                                      balancing pool for the upstream service
+                                    description: Maximum % of hosts in the load 
+                                      balancing pool for the upstream service 
                                       that can be ejected.
                                     format: int32
                                     type: integer
                                   minHealthPercent:
-                                    description: Outlier detection will be
-                                      enabled as long as the associated load
-                                      balancing pool has at least
+                                    description: Outlier detection will be 
+                                      enabled as long as the associated load 
+                                      balancing pool has at least 
                                       `minHealthPercent` hosts in healthy mode.
                                     format: int32
                                     type: integer
                                   splitExternalLocalOriginErrors:
-                                    description: Determines whether to
-                                      distinguish local origin failures from
+                                    description: Determines whether to 
+                                      distinguish local origin failures from 
                                       external errors.
                                     type: boolean
                                 type: object
                               port:
-                                description: Specifies the number of a port on
-                                  the destination service on which this policy
+                                description: Specifies the number of a port on 
+                                  the destination service on which this policy 
                                   is being applied.
                                 properties:
                                   number:
@@ -1700,7 +1700,7 @@ spec:
                                     type: integer
                                 type: object
                               tls:
-                                description: TLS related settings for
+                                description: TLS related settings for 
                                   connections to the upstream service.
                                 properties:
                                   caCertificates:
@@ -1717,8 +1717,8 @@ spec:
                                     description: REQUIRED if mode is `MUTUAL`.
                                     type: string
                                   credentialName:
-                                    description: The name of the secret that
-                                      holds the TLS certs for the client
+                                    description: The name of the secret that 
+                                      holds the TLS certs for the client 
                                       including the CA certificates.
                                     type: string
                                   insecureSkipVerify:
@@ -1743,12 +1743,12 @@ spec:
                                     description: REQUIRED if mode is `MUTUAL`.
                                     type: string
                                   sni:
-                                    description: SNI string to present to the
+                                    description: SNI string to present to the 
                                       server during TLS handshake.
                                     type: string
                                   subjectAltNames:
-                                    description: A list of alternate names to
-                                      verify the subject identity in the
+                                    description: A list of alternate names to 
+                                      verify the subject identity in the 
                                       certificate.
                                     items:
                                       type: string
@@ -1771,18 +1771,18 @@ spec:
                               type: string
                           type: object
                         retryBudget:
-                          description: Specifies a limit on concurrent retries
+                          description: Specifies a limit on concurrent retries 
                             in relation to the number of active requests.
                           properties:
                             minRetryConcurrency:
-                              description: Specifies the minimum retry
+                              description: Specifies the minimum retry 
                                 concurrency allowed for the retry budget.
                               maximum: 4294967295
                               minimum: 0
                               type: integer
                             percent:
-                              description: Specifies the limit on concurrent
-                                retries as a percentage of the sum of active
+                              description: Specifies the limit on concurrent 
+                                retries as a percentage of the sum of active 
                                 requests and active pending requests.
                               format: double
                               maximum: 100
@@ -1791,7 +1791,7 @@ spec:
                               type: number
                           type: object
                         tls:
-                          description: TLS related settings for connections to
+                          description: TLS related settings for connections to 
                             the upstream service.
                           properties:
                             caCertificates:
@@ -1809,7 +1809,7 @@ spec:
                               type: string
                             credentialName:
                               description: The name of the secret that holds the
-                                TLS certs for the client including the CA
+                                TLS certs for the client including the CA 
                                 certificates.
                               type: string
                             insecureSkipVerify:
@@ -1834,11 +1834,11 @@ spec:
                               description: REQUIRED if mode is `MUTUAL`.
                               type: string
                             sni:
-                              description: SNI string to present to the server
+                              description: SNI string to present to the server 
                                 during TLS handshake.
                               type: string
                             subjectAltNames:
-                              description: A list of alternate names to verify
+                              description: A list of alternate names to verify 
                                 the subject identity in the certificate.
                               items:
                                 type: string
@@ -1846,19 +1846,19 @@ spec:
                           type: object
                         tunnel:
                           description: Configuration of tunneling TCP over other
-                            transport or application layers for the host
+                            transport or application layers for the host 
                             configured in the DestinationRule.
                           properties:
                             protocol:
-                              description: Specifies which protocol to use for
+                              description: Specifies which protocol to use for 
                                 tunneling the downstream connection.
                               type: string
                             targetHost:
-                              description: Specifies a host to which the
+                              description: Specifies a host to which the 
                                 downstream connection is tunneled.
                               type: string
                             targetPort:
-                              description: Specifies a port to which the
+                              description: Specifies a port to which the 
                                 downstream connection is tunneled.
                               maximum: 4294967295
                               minimum: 0
@@ -1873,7 +1873,7 @@ spec:
                   type: object
                 type: array
               trafficPolicy:
-                description: Traffic policies to apply (load balancing policy,
+                description: Traffic policies to apply (load balancing policy, 
                   connection pool sizes, outlier detection).
                 properties:
                   connectionPool:
@@ -1893,36 +1893,36 @@ spec:
                             type: string
                           http1MaxPendingRequests:
                             description: Maximum number of requests that will be
-                              queued while waiting for a ready connection pool
+                              queued while waiting for a ready connection pool 
                               connection.
                             format: int32
                             type: integer
                           http2MaxRequests:
-                            description: Maximum number of active requests to a
+                            description: Maximum number of active requests to a 
                               destination.
                             format: int32
                             type: integer
                           idleTimeout:
-                            description: The idle timeout for upstream
+                            description: The idle timeout for upstream 
                               connection pool connections.
                             type: string
                             x-kubernetes-validations:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           maxConcurrentStreams:
-                            description: The maximum number of concurrent
-                              streams allowed for a peer on one HTTP/2
+                            description: The maximum number of concurrent 
+                              streams allowed for a peer on one HTTP/2 
                               connection.
                             format: int32
                             type: integer
                           maxRequestsPerConnection:
-                            description: Maximum number of requests per
+                            description: Maximum number of requests per 
                               connection to a backend.
                             format: int32
                             type: integer
                           maxRetries:
-                            description: Maximum number of retries that can be
-                              outstanding to all hosts in a cluster at a given
+                            description: Maximum number of retries that can be 
+                              outstanding to all hosts in a cluster at a given 
                               time.
                             format: int32
                             type: integer
@@ -1932,7 +1932,7 @@ spec:
                             type: boolean
                         type: object
                       tcp:
-                        description: Settings common to both HTTP and TCP
+                        description: Settings common to both HTTP and TCP 
                           upstream connections.
                         properties:
                           connectTimeout:
@@ -1951,16 +1951,16 @@ spec:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           maxConnections:
-                            description: Maximum number of HTTP1 /TCP
+                            description: Maximum number of HTTP1 /TCP 
                               connections to a destination host.
                             format: int32
                             type: integer
                           tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the
+                            description: If set then set SO_KEEPALIVE on the 
                               socket to enable TCP Keepalives.
                             properties:
                               interval:
-                                description: The time duration between
+                                description: The time duration between 
                                   keep-alive probes.
                                 type: string
                                 x-kubernetes-validations:
@@ -1968,15 +1968,15 @@ spec:
                                     1ms
                                   rule: duration(self) >= duration('1ms')
                               probes:
-                                description: Maximum number of keepalive probes
-                                  to send without response before deciding the
+                                description: Maximum number of keepalive probes 
+                                  to send without response before deciding the 
                                   connection is dead.
                                 maximum: 4294967295
                                 minimum: 0
                                 type: integer
                               time:
-                                description: The time duration a connection
-                                  needs to be idle before keep-alive probes
+                                description: The time duration a connection 
+                                  needs to be idle before keep-alive probes 
                                   start being sent.
                                 type: string
                                 x-kubernetes-validations:
@@ -1987,7 +1987,7 @@ spec:
                         type: object
                     type: object
                   loadBalancer:
-                    description: Settings controlling the load balancer
+                    description: Settings controlling the load balancer 
                       algorithms.
                     oneOf:
                     - not:
@@ -2038,16 +2038,16 @@ spec:
                             description: Hash based on HTTP cookie.
                             properties:
                               attributes:
-                                description: Additional attributes for the
+                                description: Additional attributes for the 
                                   cookie.
                                 items:
                                   properties:
                                     name:
-                                      description: The name of the cookie
+                                      description: The name of the cookie 
                                         attribute.
                                       type: string
                                     value:
-                                      description: The optional value of the
+                                      description: The optional value of the 
                                         cookie attribute.
                                       type: string
                                   required:
@@ -2070,11 +2070,11 @@ spec:
                             description: Hash based on a specific HTTP header.
                             type: string
                           httpQueryParameterName:
-                            description: Hash based on a specific HTTP query
+                            description: Hash based on a specific HTTP query 
                               parameter.
                             type: string
                           maglev:
-                            description: The Maglev load balancer implements
+                            description: The Maglev load balancer implements 
                               consistent hashing to backend hosts.
                             properties:
                               tableSize:
@@ -2087,7 +2087,7 @@ spec:
                             minimum: 0
                             type: integer
                           ringHash:
-                            description: The ring/modulo hash load balancer
+                            description: The ring/modulo hash load balancer 
                               implements consistent hashing to backend hosts.
                             properties:
                               minimumRingSize:
@@ -2108,7 +2108,7 @@ spec:
                             items:
                               properties:
                                 from:
-                                  description: Originating locality, '/'
+                                  description: Originating locality, '/' 
                                     separated, e.g.
                                   type: string
                                 to:
@@ -2116,7 +2116,7 @@ spec:
                                     maximum: 4294967295
                                     minimum: 0
                                     type: integer
-                                  description: Map of upstream localities to
+                                  description: Map of upstream localities to 
                                     traffic distribution weights.
                                   type: object
                               type: object
@@ -2134,14 +2134,14 @@ spec:
                                   description: Originating region.
                                   type: string
                                 to:
-                                  description: Destination region the traffic
-                                    will fail over to when endpoints in the
+                                  description: Destination region the traffic 
+                                    will fail over to when endpoints in the 
                                     'from' region becomes unhealthy.
                                   type: string
                               type: object
                             type: array
                           failoverPriority:
-                            description: failoverPriority is an ordered list of
+                            description: failoverPriority is an ordered list of 
                               labels used to sort endpoints to do priority based
                               load balancing.
                             items:
@@ -2162,11 +2162,11 @@ spec:
                         - LEAST_REQUEST
                         type: string
                       warmup:
-                        description: Represents the warmup configuration of
+                        description: Represents the warmup configuration of 
                           Service.
                         properties:
                           aggression:
-                            description: This parameter controls the speed of
+                            description: This parameter controls the speed of 
                               traffic increase over the warmup duration.
                             format: double
                             minimum: 0
@@ -2202,7 +2202,7 @@ spec:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is
+                        description: Number of 5xx errors before a host is 
                           ejected from the connection pool.
                         maximum: 4294967295
                         minimum: 0
@@ -2212,39 +2212,39 @@ spec:
                         format: int32
                         type: integer
                       consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is
+                        description: Number of gateway errors before a host is 
                           ejected from the connection pool.
                         maximum: 4294967295
                         minimum: 0
                         nullable: true
                         type: integer
                       consecutiveLocalOriginFailures:
-                        description: The number of consecutive locally
+                        description: The number of consecutive locally 
                           originated failures before ejection occurs.
                         maximum: 4294967295
                         minimum: 0
                         nullable: true
                         type: integer
                       interval:
-                        description: Time interval between ejection sweep
+                        description: Time interval between ejection sweep 
                           analysis.
                         type: string
                         x-kubernetes-validations:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       maxEjectionPercent:
-                        description: Maximum % of hosts in the load balancing
+                        description: Maximum % of hosts in the load balancing 
                           pool for the upstream service that can be ejected.
                         format: int32
                         type: integer
                       minHealthPercent:
-                        description: Outlier detection will be enabled as long
-                          as the associated load balancing pool has at least
+                        description: Outlier detection will be enabled as long 
+                          as the associated load balancing pool has at least 
                           `minHealthPercent` hosts in healthy mode.
                         format: int32
                         type: integer
                       splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local
+                        description: Determines whether to distinguish local 
                           origin failures from external errors.
                         type: boolean
                     type: object
@@ -2268,8 +2268,8 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of requests that
-                                    will be queued while waiting for a ready
+                                  description: Maximum number of requests that 
+                                    will be queued while waiting for a ready 
                                     connection pool connection.
                                   format: int32
                                   type: integer
@@ -2279,97 +2279,97 @@ spec:
                                   format: int32
                                   type: integer
                                 idleTimeout:
-                                  description: The idle timeout for upstream
+                                  description: The idle timeout for upstream 
                                     connection pool connections.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConcurrentStreams:
-                                  description: The maximum number of concurrent
-                                    streams allowed for a peer on one HTTP/2
+                                  description: The maximum number of concurrent 
+                                    streams allowed for a peer on one HTTP/2 
                                     connection.
                                   format: int32
                                   type: integer
                                 maxRequestsPerConnection:
-                                  description: Maximum number of requests per
+                                  description: Maximum number of requests per 
                                     connection to a backend.
                                   format: int32
                                   type: integer
                                 maxRetries:
-                                  description: Maximum number of retries that
+                                  description: Maximum number of retries that 
                                     can be outstanding to all hosts in a cluster
                                     at a given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
-                                  description: If set to true, client protocol
-                                    will be preserved while initiating
+                                  description: If set to true, client protocol 
+                                    will be preserved while initiating 
                                     connection to backend.
                                   type: boolean
                               type: object
                             tcp:
-                              description: Settings common to both HTTP and TCP
+                              description: Settings common to both HTTP and TCP 
                                 upstream connections.
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 idleTimeout:
-                                  description: The idle timeout for TCP
+                                  description: The idle timeout for TCP 
                                     connections.
                                   type: string
                                 maxConnectionDuration:
-                                  description: The maximum duration of a
+                                  description: The maximum duration of a 
                                     connection.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConnections:
-                                  description: Maximum number of HTTP1 /TCP
+                                  description: Maximum number of HTTP1 /TCP 
                                     connections to a destination host.
                                   format: int32
                                   type: integer
                                 tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on
+                                  description: If set then set SO_KEEPALIVE on 
                                     the socket to enable TCP Keepalives.
                                   properties:
                                     interval:
-                                      description: The time duration between
+                                      description: The time duration between 
                                         keep-alive probes.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                     probes:
-                                      description: Maximum number of keepalive
-                                        probes to send without response before
+                                      description: Maximum number of keepalive 
+                                        probes to send without response before 
                                         deciding the connection is dead.
                                       maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                     time:
-                                      description: The time duration a
-                                        connection needs to be idle before
+                                      description: The time duration a 
+                                        connection needs to be idle before 
                                         keep-alive probes start being sent.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                   type: object
                               type: object
                           type: object
                         loadBalancer:
-                          description: Settings controlling the load balancer
+                          description: Settings controlling the load balancer 
                             algorithms.
                           oneOf:
                           - not:
@@ -2425,11 +2425,11 @@ spec:
                                       items:
                                         properties:
                                           name:
-                                            description: The name of the cookie
+                                            description: The name of the cookie 
                                               attribute.
                                             type: string
                                           value:
-                                            description: The optional value of
+                                            description: The optional value of 
                                               the cookie attribute.
                                             type: string
                                         required:
@@ -2449,20 +2449,20 @@ spec:
                                   - name
                                   type: object
                                 httpHeaderName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     header.
                                   type: string
                                 httpQueryParameterName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     query parameter.
                                   type: string
                                 maglev:
-                                  description: The Maglev load balancer
-                                    implements consistent hashing to backend
+                                  description: The Maglev load balancer 
+                                    implements consistent hashing to backend 
                                     hosts.
                                   properties:
                                     tableSize:
-                                      description: The table size for Maglev
+                                      description: The table size for Maglev 
                                         hashing.
                                       minimum: 0
                                       type: integer
@@ -2472,8 +2472,8 @@ spec:
                                   minimum: 0
                                   type: integer
                                 ringHash:
-                                  description: The ring/modulo hash load
-                                    balancer implements consistent hashing to
+                                  description: The ring/modulo hash load 
+                                    balancer implements consistent hashing to 
                                     backend hosts.
                                   properties:
                                     minimumRingSize:
@@ -2483,7 +2483,7 @@ spec:
                                       type: integer
                                   type: object
                                 useSourceIp:
-                                  description: Hash based on the source IP
+                                  description: Hash based on the source IP 
                                     address.
                                   type: boolean
                               type: object
@@ -2495,7 +2495,7 @@ spec:
                                   items:
                                     properties:
                                       from:
-                                        description: Originating locality, '/'
+                                        description: Originating locality, '/' 
                                           separated, e.g.
                                         type: string
                                       to:
@@ -2503,7 +2503,7 @@ spec:
                                           maximum: 4294967295
                                           minimum: 0
                                           type: integer
-                                        description: Map of upstream localities
+                                        description: Map of upstream localities 
                                           to traffic distribution weights.
                                         type: object
                                     type: object
@@ -2521,16 +2521,16 @@ spec:
                                         description: Originating region.
                                         type: string
                                       to:
-                                        description: Destination region the
-                                          traffic will fail over to when
+                                        description: Destination region the 
+                                          traffic will fail over to when 
                                           endpoints in the 'from' region becomes
                                           unhealthy.
                                         type: string
                                     type: object
                                   type: array
                                 failoverPriority:
-                                  description: failoverPriority is an ordered
-                                    list of labels used to sort endpoints to do
+                                  description: failoverPriority is an ordered 
+                                    list of labels used to sort endpoints to do 
                                     priority based load balancing.
                                   items:
                                     type: string
@@ -2550,12 +2550,12 @@ spec:
                               - LEAST_REQUEST
                               type: string
                             warmup:
-                              description: Represents the warmup configuration
+                              description: Represents the warmup configuration 
                                 of Service.
                               properties:
                                 aggression:
                                   description: This parameter controls the speed
-                                    of traffic increase over the warmup
+                                    of traffic increase over the warmup 
                                     duration.
                                   format: double
                                   minimum: 0
@@ -2564,7 +2564,7 @@ spec:
                                 duration:
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 minimumPercent:
@@ -2580,7 +2580,7 @@ spec:
                               description: 'Deprecated: use `warmup` instead.'
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                           type: object
@@ -2590,7 +2590,7 @@ spec:
                               description: Minimum ejection duration.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             consecutive5xxErrors:
@@ -2604,48 +2604,48 @@ spec:
                               format: int32
                               type: integer
                             consecutiveGatewayErrors:
-                              description: Number of gateway errors before a
+                              description: Number of gateway errors before a 
                                 host is ejected from the connection pool.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally
+                              description: The number of consecutive locally 
                                 originated failures before ejection occurs.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             interval:
-                              description: Time interval between ejection sweep
+                              description: Time interval between ejection sweep 
                                 analysis.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxEjectionPercent:
-                              description: Maximum % of hosts in the load
+                              description: Maximum % of hosts in the load 
                                 balancing pool for the upstream service that can
                                 be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
-                              description: Outlier detection will be enabled as
-                                long as the associated load balancing pool has
-                                at least `minHealthPercent` hosts in healthy
+                              description: Outlier detection will be enabled as 
+                                long as the associated load balancing pool has 
+                                at least `minHealthPercent` hosts in healthy 
                                 mode.
                               format: int32
                               type: integer
                             splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish
+                              description: Determines whether to distinguish 
                                 local origin failures from external errors.
                               type: boolean
                           type: object
                         port:
-                          description: Specifies the number of a port on the
-                            destination service on which this policy is being
+                          description: Specifies the number of a port on the 
+                            destination service on which this policy is being 
                             applied.
                           properties:
                             number:
@@ -2654,7 +2654,7 @@ spec:
                               type: integer
                           type: object
                         tls:
-                          description: TLS related settings for connections to
+                          description: TLS related settings for connections to 
                             the upstream service.
                           properties:
                             caCertificates:
@@ -2672,7 +2672,7 @@ spec:
                               type: string
                             credentialName:
                               description: The name of the secret that holds the
-                                TLS certs for the client including the CA
+                                TLS certs for the client including the CA 
                                 certificates.
                               type: string
                             insecureSkipVerify:
@@ -2697,11 +2697,11 @@ spec:
                               description: REQUIRED if mode is `MUTUAL`.
                               type: string
                             sni:
-                              description: SNI string to present to the server
+                              description: SNI string to present to the server 
                                 during TLS handshake.
                               type: string
                             subjectAltNames:
-                              description: A list of alternate names to verify
+                              description: A list of alternate names to verify 
                                 the subject identity in the certificate.
                               items:
                                 type: string
@@ -2724,18 +2724,18 @@ spec:
                         type: string
                     type: object
                   retryBudget:
-                    description: Specifies a limit on concurrent retries in
+                    description: Specifies a limit on concurrent retries in 
                       relation to the number of active requests.
                     properties:
                       minRetryConcurrency:
-                        description: Specifies the minimum retry concurrency
+                        description: Specifies the minimum retry concurrency 
                           allowed for the retry budget.
                         maximum: 4294967295
                         minimum: 0
                         type: integer
                       percent:
-                        description: Specifies the limit on concurrent retries
-                          as a percentage of the sum of active requests and
+                        description: Specifies the limit on concurrent retries 
+                          as a percentage of the sum of active requests and 
                           active pending requests.
                         format: double
                         maximum: 100
@@ -2744,7 +2744,7 @@ spec:
                         type: number
                     type: object
                   tls:
-                    description: TLS related settings for connections to the
+                    description: TLS related settings for connections to the 
                       upstream service.
                     properties:
                       caCertificates:
@@ -2761,7 +2761,7 @@ spec:
                         description: REQUIRED if mode is `MUTUAL`.
                         type: string
                       credentialName:
-                        description: The name of the secret that holds the TLS
+                        description: The name of the secret that holds the TLS 
                           certs for the client including the CA certificates.
                         type: string
                       insecureSkipVerify:
@@ -2785,31 +2785,31 @@ spec:
                         description: REQUIRED if mode is `MUTUAL`.
                         type: string
                       sni:
-                        description: SNI string to present to the server during
+                        description: SNI string to present to the server during 
                           TLS handshake.
                         type: string
                       subjectAltNames:
-                        description: A list of alternate names to verify the
+                        description: A list of alternate names to verify the 
                           subject identity in the certificate.
                         items:
                           type: string
                         type: array
                     type: object
                   tunnel:
-                    description: Configuration of tunneling TCP over other
+                    description: Configuration of tunneling TCP over other 
                       transport or application layers for the host configured in
                       the DestinationRule.
                     properties:
                       protocol:
-                        description: Specifies which protocol to use for
+                        description: Specifies which protocol to use for 
                           tunneling the downstream connection.
                         type: string
                       targetHost:
-                        description: Specifies a host to which the downstream
+                        description: Specifies a host to which the downstream 
                           connection is tunneled.
                         type: string
                       targetPort:
-                        description: Specifies a port to which the downstream
+                        description: Specifies a port to which the downstream 
                           connection is tunneled.
                         maximum: 4294967295
                         minimum: 0
@@ -2820,8 +2820,8 @@ spec:
                     type: object
                 type: object
               workloadSelector:
-                description: Criteria used to select the specific set of
-                  pods/VMs on which this `DestinationRule` configuration should
+                description: Criteria used to select the specific set of 
+                  pods/VMs on which this `DestinationRule` configuration should 
                   be applied.
                 properties:
                   matchLabels:
@@ -2860,18 +2860,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -2910,12 +2910,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -2934,11 +2934,11 @@ spec:
       name: Host
       type: string
     - description: CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in
-        happens-before order across separate operations. Clients may not set
-        this value. It is represented in RFC3339 form and is in UTC. Populated
-        by the system. Read-only. Null for lists. For more information, see
-        [Kubernetes API
+        when this object was created. It is not guaranteed to be set in 
+        happens-before order across separate operations. Clients may not set 
+        this value. It is represented in RFC3339 form and is in UTC. Populated 
+        by the system. Read-only. Null for lists. For more information, see 
+        [Kubernetes API 
         Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -2961,7 +2961,7 @@ spec:
                 description: The name of a service from the service registry.
                 type: string
               subsets:
-                description: One or more named sets that represent individual
+                description: One or more named sets that represent individual 
                   versions of a service.
                 items:
                   properties:
@@ -2993,8 +2993,8 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of requests that
-                                    will be queued while waiting for a ready
+                                  description: Maximum number of requests that 
+                                    will be queued while waiting for a ready 
                                     connection pool connection.
                                   format: int32
                                   type: integer
@@ -3004,97 +3004,97 @@ spec:
                                   format: int32
                                   type: integer
                                 idleTimeout:
-                                  description: The idle timeout for upstream
+                                  description: The idle timeout for upstream 
                                     connection pool connections.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConcurrentStreams:
-                                  description: The maximum number of concurrent
-                                    streams allowed for a peer on one HTTP/2
+                                  description: The maximum number of concurrent 
+                                    streams allowed for a peer on one HTTP/2 
                                     connection.
                                   format: int32
                                   type: integer
                                 maxRequestsPerConnection:
-                                  description: Maximum number of requests per
+                                  description: Maximum number of requests per 
                                     connection to a backend.
                                   format: int32
                                   type: integer
                                 maxRetries:
-                                  description: Maximum number of retries that
+                                  description: Maximum number of retries that 
                                     can be outstanding to all hosts in a cluster
                                     at a given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
-                                  description: If set to true, client protocol
-                                    will be preserved while initiating
+                                  description: If set to true, client protocol 
+                                    will be preserved while initiating 
                                     connection to backend.
                                   type: boolean
                               type: object
                             tcp:
-                              description: Settings common to both HTTP and TCP
+                              description: Settings common to both HTTP and TCP 
                                 upstream connections.
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 idleTimeout:
-                                  description: The idle timeout for TCP
+                                  description: The idle timeout for TCP 
                                     connections.
                                   type: string
                                 maxConnectionDuration:
-                                  description: The maximum duration of a
+                                  description: The maximum duration of a 
                                     connection.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConnections:
-                                  description: Maximum number of HTTP1 /TCP
+                                  description: Maximum number of HTTP1 /TCP 
                                     connections to a destination host.
                                   format: int32
                                   type: integer
                                 tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on
+                                  description: If set then set SO_KEEPALIVE on 
                                     the socket to enable TCP Keepalives.
                                   properties:
                                     interval:
-                                      description: The time duration between
+                                      description: The time duration between 
                                         keep-alive probes.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                     probes:
-                                      description: Maximum number of keepalive
-                                        probes to send without response before
+                                      description: Maximum number of keepalive 
+                                        probes to send without response before 
                                         deciding the connection is dead.
                                       maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                     time:
-                                      description: The time duration a
-                                        connection needs to be idle before
+                                      description: The time duration a 
+                                        connection needs to be idle before 
                                         keep-alive probes start being sent.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                   type: object
                               type: object
                           type: object
                         loadBalancer:
-                          description: Settings controlling the load balancer
+                          description: Settings controlling the load balancer 
                             algorithms.
                           oneOf:
                           - not:
@@ -3150,11 +3150,11 @@ spec:
                                       items:
                                         properties:
                                           name:
-                                            description: The name of the cookie
+                                            description: The name of the cookie 
                                               attribute.
                                             type: string
                                           value:
-                                            description: The optional value of
+                                            description: The optional value of 
                                               the cookie attribute.
                                             type: string
                                         required:
@@ -3174,20 +3174,20 @@ spec:
                                   - name
                                   type: object
                                 httpHeaderName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     header.
                                   type: string
                                 httpQueryParameterName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     query parameter.
                                   type: string
                                 maglev:
-                                  description: The Maglev load balancer
-                                    implements consistent hashing to backend
+                                  description: The Maglev load balancer 
+                                    implements consistent hashing to backend 
                                     hosts.
                                   properties:
                                     tableSize:
-                                      description: The table size for Maglev
+                                      description: The table size for Maglev 
                                         hashing.
                                       minimum: 0
                                       type: integer
@@ -3197,8 +3197,8 @@ spec:
                                   minimum: 0
                                   type: integer
                                 ringHash:
-                                  description: The ring/modulo hash load
-                                    balancer implements consistent hashing to
+                                  description: The ring/modulo hash load 
+                                    balancer implements consistent hashing to 
                                     backend hosts.
                                   properties:
                                     minimumRingSize:
@@ -3208,7 +3208,7 @@ spec:
                                       type: integer
                                   type: object
                                 useSourceIp:
-                                  description: Hash based on the source IP
+                                  description: Hash based on the source IP 
                                     address.
                                   type: boolean
                               type: object
@@ -3220,7 +3220,7 @@ spec:
                                   items:
                                     properties:
                                       from:
-                                        description: Originating locality, '/'
+                                        description: Originating locality, '/' 
                                           separated, e.g.
                                         type: string
                                       to:
@@ -3228,7 +3228,7 @@ spec:
                                           maximum: 4294967295
                                           minimum: 0
                                           type: integer
-                                        description: Map of upstream localities
+                                        description: Map of upstream localities 
                                           to traffic distribution weights.
                                         type: object
                                     type: object
@@ -3246,16 +3246,16 @@ spec:
                                         description: Originating region.
                                         type: string
                                       to:
-                                        description: Destination region the
-                                          traffic will fail over to when
+                                        description: Destination region the 
+                                          traffic will fail over to when 
                                           endpoints in the 'from' region becomes
                                           unhealthy.
                                         type: string
                                     type: object
                                   type: array
                                 failoverPriority:
-                                  description: failoverPriority is an ordered
-                                    list of labels used to sort endpoints to do
+                                  description: failoverPriority is an ordered 
+                                    list of labels used to sort endpoints to do 
                                     priority based load balancing.
                                   items:
                                     type: string
@@ -3275,12 +3275,12 @@ spec:
                               - LEAST_REQUEST
                               type: string
                             warmup:
-                              description: Represents the warmup configuration
+                              description: Represents the warmup configuration 
                                 of Service.
                               properties:
                                 aggression:
                                   description: This parameter controls the speed
-                                    of traffic increase over the warmup
+                                    of traffic increase over the warmup 
                                     duration.
                                   format: double
                                   minimum: 0
@@ -3289,7 +3289,7 @@ spec:
                                 duration:
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 minimumPercent:
@@ -3305,7 +3305,7 @@ spec:
                               description: 'Deprecated: use `warmup` instead.'
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                           type: object
@@ -3315,7 +3315,7 @@ spec:
                               description: Minimum ejection duration.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             consecutive5xxErrors:
@@ -3329,47 +3329,47 @@ spec:
                               format: int32
                               type: integer
                             consecutiveGatewayErrors:
-                              description: Number of gateway errors before a
+                              description: Number of gateway errors before a 
                                 host is ejected from the connection pool.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally
+                              description: The number of consecutive locally 
                                 originated failures before ejection occurs.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             interval:
-                              description: Time interval between ejection sweep
+                              description: Time interval between ejection sweep 
                                 analysis.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxEjectionPercent:
-                              description: Maximum % of hosts in the load
+                              description: Maximum % of hosts in the load 
                                 balancing pool for the upstream service that can
                                 be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
-                              description: Outlier detection will be enabled as
-                                long as the associated load balancing pool has
-                                at least `minHealthPercent` hosts in healthy
+                              description: Outlier detection will be enabled as 
+                                long as the associated load balancing pool has 
+                                at least `minHealthPercent` hosts in healthy 
                                 mode.
                               format: int32
                               type: integer
                             splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish
+                              description: Determines whether to distinguish 
                                 local origin failures from external errors.
                               type: boolean
                           type: object
                         portLevelSettings:
-                          description: Traffic policies specific to individual
+                          description: Traffic policies specific to individual 
                             ports.
                           items:
                             properties:
@@ -3389,117 +3389,117 @@ spec:
                                         - UPGRADE
                                         type: string
                                       http1MaxPendingRequests:
-                                        description: Maximum number of requests
-                                          that will be queued while waiting for
+                                        description: Maximum number of requests 
+                                          that will be queued while waiting for 
                                           a ready connection pool connection.
                                         format: int32
                                         type: integer
                                       http2MaxRequests:
-                                        description: Maximum number of active
+                                        description: Maximum number of active 
                                           requests to a destination.
                                         format: int32
                                         type: integer
                                       idleTimeout:
-                                        description: The idle timeout for
+                                        description: The idle timeout for 
                                           upstream connection pool connections.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       maxConcurrentStreams:
-                                        description: The maximum number of
-                                          concurrent streams allowed for a peer
+                                        description: The maximum number of 
+                                          concurrent streams allowed for a peer 
                                           on one HTTP/2 connection.
                                         format: int32
                                         type: integer
                                       maxRequestsPerConnection:
-                                        description: Maximum number of requests
+                                        description: Maximum number of requests 
                                           per connection to a backend.
                                         format: int32
                                         type: integer
                                       maxRetries:
-                                        description: Maximum number of retries
-                                          that can be outstanding to all hosts
+                                        description: Maximum number of retries 
+                                          that can be outstanding to all hosts 
                                           in a cluster at a given time.
                                         format: int32
                                         type: integer
                                       useClientProtocol:
-                                        description: If set to true, client
-                                          protocol will be preserved while
+                                        description: If set to true, client 
+                                          protocol will be preserved while 
                                           initiating connection to backend.
                                         type: boolean
                                     type: object
                                   tcp:
-                                    description: Settings common to both HTTP
+                                    description: Settings common to both HTTP 
                                       and TCP upstream connections.
                                     properties:
                                       connectTimeout:
                                         description: TCP connection timeout.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       idleTimeout:
-                                        description: The idle timeout for TCP
+                                        description: The idle timeout for TCP 
                                           connections.
                                         type: string
                                       maxConnectionDuration:
-                                        description: The maximum duration of a
+                                        description: The maximum duration of a 
                                           connection.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       maxConnections:
-                                        description: Maximum number of HTTP1
-                                          /TCP connections to a destination
+                                        description: Maximum number of HTTP1 
+                                          /TCP connections to a destination 
                                           host.
                                         format: int32
                                         type: integer
                                       tcpKeepalive:
-                                        description: If set then set
-                                          SO_KEEPALIVE on the socket to enable
+                                        description: If set then set 
+                                          SO_KEEPALIVE on the socket to enable 
                                           TCP Keepalives.
                                         properties:
                                           interval:
-                                            description: The time duration
+                                            description: The time duration 
                                               between keep-alive probes.
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: must be a valid duration
+                                            - message: must be a valid duration 
                                                 greater than 1ms
-                                              rule: duration(self) >=
+                                              rule: duration(self) >= 
                                                 duration('1ms')
                                           probes:
-                                            description: Maximum number of
-                                              keepalive probes to send without
-                                              response before deciding the
+                                            description: Maximum number of 
+                                              keepalive probes to send without 
+                                              response before deciding the 
                                               connection is dead.
                                             maximum: 4294967295
                                             minimum: 0
                                             type: integer
                                           time:
-                                            description: The time duration a
+                                            description: The time duration a 
                                               connection needs to be idle before
-                                              keep-alive probes start being
+                                              keep-alive probes start being 
                                               sent.
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: must be a valid duration
+                                            - message: must be a valid duration 
                                                 greater than 1ms
-                                              rule: duration(self) >=
+                                              rule: duration(self) >= 
                                                 duration('1ms')
                                         type: object
                                     type: object
                                 type: object
                               loadBalancer:
-                                description: Settings controlling the load
+                                description: Settings controlling the load 
                                   balancer algorithms.
                                 oneOf:
                                 - not:
@@ -3550,17 +3550,17 @@ spec:
                                         description: Hash based on HTTP cookie.
                                         properties:
                                           attributes:
-                                            description: Additional attributes
+                                            description: Additional attributes 
                                               for the cookie.
                                             items:
                                               properties:
                                                 name:
-                                                  description: The name of the
+                                                  description: The name of the 
                                                     cookie attribute.
                                                   type: string
                                                 value:
-                                                  description: The optional
-                                                    value of the cookie
+                                                  description: The optional 
+                                                    value of the cookie 
                                                     attribute.
                                                   type: string
                                               required:
@@ -3571,7 +3571,7 @@ spec:
                                             description: Name of the cookie.
                                             type: string
                                           path:
-                                            description: Path to set for the
+                                            description: Path to set for the 
                                               cookie.
                                             type: string
                                           ttl:
@@ -3581,20 +3581,20 @@ spec:
                                         - name
                                         type: object
                                       httpHeaderName:
-                                        description: Hash based on a specific
+                                        description: Hash based on a specific 
                                           HTTP header.
                                         type: string
                                       httpQueryParameterName:
-                                        description: Hash based on a specific
+                                        description: Hash based on a specific 
                                           HTTP query parameter.
                                         type: string
                                       maglev:
-                                        description: The Maglev load balancer
-                                          implements consistent hashing to
+                                        description: The Maglev load balancer 
+                                          implements consistent hashing to 
                                           backend hosts.
                                         properties:
                                           tableSize:
-                                            description: The table size for
+                                            description: The table size for 
                                               Maglev hashing.
                                             minimum: 0
                                             type: integer
@@ -3604,13 +3604,13 @@ spec:
                                         minimum: 0
                                         type: integer
                                       ringHash:
-                                        description: The ring/modulo hash load
+                                        description: The ring/modulo hash load 
                                           balancer implements consistent hashing
                                           to backend hosts.
                                         properties:
                                           minimumRingSize:
-                                            description: The minimum number of
-                                              virtual nodes to use for the hash
+                                            description: The minimum number of 
+                                              virtual nodes to use for the hash 
                                               ring.
                                             minimum: 0
                                             type: integer
@@ -3636,14 +3636,14 @@ spec:
                                                 maximum: 4294967295
                                                 minimum: 0
                                                 type: integer
-                                              description: Map of upstream
-                                                localities to traffic
+                                              description: Map of upstream 
+                                                localities to traffic 
                                                 distribution weights.
                                               type: object
                                           type: object
                                         type: array
                                       enabled:
-                                        description: Enable locality load
+                                        description: Enable locality load 
                                           balancing.
                                         nullable: true
                                         type: boolean
@@ -3656,17 +3656,17 @@ spec:
                                               description: Originating region.
                                               type: string
                                             to:
-                                              description: Destination region
-                                                the traffic will fail over to
-                                                when endpoints in the 'from'
+                                              description: Destination region 
+                                                the traffic will fail over to 
+                                                when endpoints in the 'from' 
                                                 region becomes unhealthy.
                                               type: string
                                           type: object
                                         type: array
                                       failoverPriority:
-                                        description: failoverPriority is an
-                                          ordered list of labels used to sort
-                                          endpoints to do priority based load
+                                        description: failoverPriority is an 
+                                          ordered list of labels used to sort 
+                                          endpoints to do priority based load 
                                           balancing.
                                         items:
                                           type: string
@@ -3686,12 +3686,12 @@ spec:
                                     - LEAST_REQUEST
                                     type: string
                                   warmup:
-                                    description: Represents the warmup
+                                    description: Represents the warmup 
                                       configuration of Service.
                                     properties:
                                       aggression:
                                         description: This parameter controls the
-                                          speed of traffic increase over the
+                                          speed of traffic increase over the 
                                           warmup duration.
                                         format: double
                                         minimum: 0
@@ -3700,9 +3700,9 @@ spec:
                                       duration:
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       minimumPercent:
                                         format: double
@@ -3717,7 +3717,7 @@ spec:
                                     description: 'Deprecated: use `warmup` instead.'
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                 type: object
@@ -3727,11 +3727,11 @@ spec:
                                     description: Minimum ejection duration.
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                   consecutive5xxErrors:
-                                    description: Number of 5xx errors before a
+                                    description: Number of 5xx errors before a 
                                       host is ejected from the connection pool.
                                     maximum: 4294967295
                                     minimum: 0
@@ -3742,50 +3742,50 @@ spec:
                                     type: integer
                                   consecutiveGatewayErrors:
                                     description: Number of gateway errors before
-                                      a host is ejected from the connection
+                                      a host is ejected from the connection 
                                       pool.
                                     maximum: 4294967295
                                     minimum: 0
                                     nullable: true
                                     type: integer
                                   consecutiveLocalOriginFailures:
-                                    description: The number of consecutive
-                                      locally originated failures before
+                                    description: The number of consecutive 
+                                      locally originated failures before 
                                       ejection occurs.
                                     maximum: 4294967295
                                     minimum: 0
                                     nullable: true
                                     type: integer
                                   interval:
-                                    description: Time interval between ejection
+                                    description: Time interval between ejection 
                                       sweep analysis.
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                   maxEjectionPercent:
-                                    description: Maximum % of hosts in the load
-                                      balancing pool for the upstream service
+                                    description: Maximum % of hosts in the load 
+                                      balancing pool for the upstream service 
                                       that can be ejected.
                                     format: int32
                                     type: integer
                                   minHealthPercent:
-                                    description: Outlier detection will be
-                                      enabled as long as the associated load
-                                      balancing pool has at least
+                                    description: Outlier detection will be 
+                                      enabled as long as the associated load 
+                                      balancing pool has at least 
                                       `minHealthPercent` hosts in healthy mode.
                                     format: int32
                                     type: integer
                                   splitExternalLocalOriginErrors:
-                                    description: Determines whether to
-                                      distinguish local origin failures from
+                                    description: Determines whether to 
+                                      distinguish local origin failures from 
                                       external errors.
                                     type: boolean
                                 type: object
                               port:
-                                description: Specifies the number of a port on
-                                  the destination service on which this policy
+                                description: Specifies the number of a port on 
+                                  the destination service on which this policy 
                                   is being applied.
                                 properties:
                                   number:
@@ -3794,7 +3794,7 @@ spec:
                                     type: integer
                                 type: object
                               tls:
-                                description: TLS related settings for
+                                description: TLS related settings for 
                                   connections to the upstream service.
                                 properties:
                                   caCertificates:
@@ -3811,8 +3811,8 @@ spec:
                                     description: REQUIRED if mode is `MUTUAL`.
                                     type: string
                                   credentialName:
-                                    description: The name of the secret that
-                                      holds the TLS certs for the client
+                                    description: The name of the secret that 
+                                      holds the TLS certs for the client 
                                       including the CA certificates.
                                     type: string
                                   insecureSkipVerify:
@@ -3837,12 +3837,12 @@ spec:
                                     description: REQUIRED if mode is `MUTUAL`.
                                     type: string
                                   sni:
-                                    description: SNI string to present to the
+                                    description: SNI string to present to the 
                                       server during TLS handshake.
                                     type: string
                                   subjectAltNames:
-                                    description: A list of alternate names to
-                                      verify the subject identity in the
+                                    description: A list of alternate names to 
+                                      verify the subject identity in the 
                                       certificate.
                                     items:
                                       type: string
@@ -3865,18 +3865,18 @@ spec:
                               type: string
                           type: object
                         retryBudget:
-                          description: Specifies a limit on concurrent retries
+                          description: Specifies a limit on concurrent retries 
                             in relation to the number of active requests.
                           properties:
                             minRetryConcurrency:
-                              description: Specifies the minimum retry
+                              description: Specifies the minimum retry 
                                 concurrency allowed for the retry budget.
                               maximum: 4294967295
                               minimum: 0
                               type: integer
                             percent:
-                              description: Specifies the limit on concurrent
-                                retries as a percentage of the sum of active
+                              description: Specifies the limit on concurrent 
+                                retries as a percentage of the sum of active 
                                 requests and active pending requests.
                               format: double
                               maximum: 100
@@ -3885,7 +3885,7 @@ spec:
                               type: number
                           type: object
                         tls:
-                          description: TLS related settings for connections to
+                          description: TLS related settings for connections to 
                             the upstream service.
                           properties:
                             caCertificates:
@@ -3903,7 +3903,7 @@ spec:
                               type: string
                             credentialName:
                               description: The name of the secret that holds the
-                                TLS certs for the client including the CA
+                                TLS certs for the client including the CA 
                                 certificates.
                               type: string
                             insecureSkipVerify:
@@ -3928,11 +3928,11 @@ spec:
                               description: REQUIRED if mode is `MUTUAL`.
                               type: string
                             sni:
-                              description: SNI string to present to the server
+                              description: SNI string to present to the server 
                                 during TLS handshake.
                               type: string
                             subjectAltNames:
-                              description: A list of alternate names to verify
+                              description: A list of alternate names to verify 
                                 the subject identity in the certificate.
                               items:
                                 type: string
@@ -3940,19 +3940,19 @@ spec:
                           type: object
                         tunnel:
                           description: Configuration of tunneling TCP over other
-                            transport or application layers for the host
+                            transport or application layers for the host 
                             configured in the DestinationRule.
                           properties:
                             protocol:
-                              description: Specifies which protocol to use for
+                              description: Specifies which protocol to use for 
                                 tunneling the downstream connection.
                               type: string
                             targetHost:
-                              description: Specifies a host to which the
+                              description: Specifies a host to which the 
                                 downstream connection is tunneled.
                               type: string
                             targetPort:
-                              description: Specifies a port to which the
+                              description: Specifies a port to which the 
                                 downstream connection is tunneled.
                               maximum: 4294967295
                               minimum: 0
@@ -3967,7 +3967,7 @@ spec:
                   type: object
                 type: array
               trafficPolicy:
-                description: Traffic policies to apply (load balancing policy,
+                description: Traffic policies to apply (load balancing policy, 
                   connection pool sizes, outlier detection).
                 properties:
                   connectionPool:
@@ -3987,36 +3987,36 @@ spec:
                             type: string
                           http1MaxPendingRequests:
                             description: Maximum number of requests that will be
-                              queued while waiting for a ready connection pool
+                              queued while waiting for a ready connection pool 
                               connection.
                             format: int32
                             type: integer
                           http2MaxRequests:
-                            description: Maximum number of active requests to a
+                            description: Maximum number of active requests to a 
                               destination.
                             format: int32
                             type: integer
                           idleTimeout:
-                            description: The idle timeout for upstream
+                            description: The idle timeout for upstream 
                               connection pool connections.
                             type: string
                             x-kubernetes-validations:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           maxConcurrentStreams:
-                            description: The maximum number of concurrent
-                              streams allowed for a peer on one HTTP/2
+                            description: The maximum number of concurrent 
+                              streams allowed for a peer on one HTTP/2 
                               connection.
                             format: int32
                             type: integer
                           maxRequestsPerConnection:
-                            description: Maximum number of requests per
+                            description: Maximum number of requests per 
                               connection to a backend.
                             format: int32
                             type: integer
                           maxRetries:
-                            description: Maximum number of retries that can be
-                              outstanding to all hosts in a cluster at a given
+                            description: Maximum number of retries that can be 
+                              outstanding to all hosts in a cluster at a given 
                               time.
                             format: int32
                             type: integer
@@ -4026,7 +4026,7 @@ spec:
                             type: boolean
                         type: object
                       tcp:
-                        description: Settings common to both HTTP and TCP
+                        description: Settings common to both HTTP and TCP 
                           upstream connections.
                         properties:
                           connectTimeout:
@@ -4045,16 +4045,16 @@ spec:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           maxConnections:
-                            description: Maximum number of HTTP1 /TCP
+                            description: Maximum number of HTTP1 /TCP 
                               connections to a destination host.
                             format: int32
                             type: integer
                           tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the
+                            description: If set then set SO_KEEPALIVE on the 
                               socket to enable TCP Keepalives.
                             properties:
                               interval:
-                                description: The time duration between
+                                description: The time duration between 
                                   keep-alive probes.
                                 type: string
                                 x-kubernetes-validations:
@@ -4062,15 +4062,15 @@ spec:
                                     1ms
                                   rule: duration(self) >= duration('1ms')
                               probes:
-                                description: Maximum number of keepalive probes
-                                  to send without response before deciding the
+                                description: Maximum number of keepalive probes 
+                                  to send without response before deciding the 
                                   connection is dead.
                                 maximum: 4294967295
                                 minimum: 0
                                 type: integer
                               time:
-                                description: The time duration a connection
-                                  needs to be idle before keep-alive probes
+                                description: The time duration a connection 
+                                  needs to be idle before keep-alive probes 
                                   start being sent.
                                 type: string
                                 x-kubernetes-validations:
@@ -4081,7 +4081,7 @@ spec:
                         type: object
                     type: object
                   loadBalancer:
-                    description: Settings controlling the load balancer
+                    description: Settings controlling the load balancer 
                       algorithms.
                     oneOf:
                     - not:
@@ -4132,16 +4132,16 @@ spec:
                             description: Hash based on HTTP cookie.
                             properties:
                               attributes:
-                                description: Additional attributes for the
+                                description: Additional attributes for the 
                                   cookie.
                                 items:
                                   properties:
                                     name:
-                                      description: The name of the cookie
+                                      description: The name of the cookie 
                                         attribute.
                                       type: string
                                     value:
-                                      description: The optional value of the
+                                      description: The optional value of the 
                                         cookie attribute.
                                       type: string
                                   required:
@@ -4164,11 +4164,11 @@ spec:
                             description: Hash based on a specific HTTP header.
                             type: string
                           httpQueryParameterName:
-                            description: Hash based on a specific HTTP query
+                            description: Hash based on a specific HTTP query 
                               parameter.
                             type: string
                           maglev:
-                            description: The Maglev load balancer implements
+                            description: The Maglev load balancer implements 
                               consistent hashing to backend hosts.
                             properties:
                               tableSize:
@@ -4181,7 +4181,7 @@ spec:
                             minimum: 0
                             type: integer
                           ringHash:
-                            description: The ring/modulo hash load balancer
+                            description: The ring/modulo hash load balancer 
                               implements consistent hashing to backend hosts.
                             properties:
                               minimumRingSize:
@@ -4202,7 +4202,7 @@ spec:
                             items:
                               properties:
                                 from:
-                                  description: Originating locality, '/'
+                                  description: Originating locality, '/' 
                                     separated, e.g.
                                   type: string
                                 to:
@@ -4210,7 +4210,7 @@ spec:
                                     maximum: 4294967295
                                     minimum: 0
                                     type: integer
-                                  description: Map of upstream localities to
+                                  description: Map of upstream localities to 
                                     traffic distribution weights.
                                   type: object
                               type: object
@@ -4228,14 +4228,14 @@ spec:
                                   description: Originating region.
                                   type: string
                                 to:
-                                  description: Destination region the traffic
-                                    will fail over to when endpoints in the
+                                  description: Destination region the traffic 
+                                    will fail over to when endpoints in the 
                                     'from' region becomes unhealthy.
                                   type: string
                               type: object
                             type: array
                           failoverPriority:
-                            description: failoverPriority is an ordered list of
+                            description: failoverPriority is an ordered list of 
                               labels used to sort endpoints to do priority based
                               load balancing.
                             items:
@@ -4256,11 +4256,11 @@ spec:
                         - LEAST_REQUEST
                         type: string
                       warmup:
-                        description: Represents the warmup configuration of
+                        description: Represents the warmup configuration of 
                           Service.
                         properties:
                           aggression:
-                            description: This parameter controls the speed of
+                            description: This parameter controls the speed of 
                               traffic increase over the warmup duration.
                             format: double
                             minimum: 0
@@ -4296,7 +4296,7 @@ spec:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is
+                        description: Number of 5xx errors before a host is 
                           ejected from the connection pool.
                         maximum: 4294967295
                         minimum: 0
@@ -4306,39 +4306,39 @@ spec:
                         format: int32
                         type: integer
                       consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is
+                        description: Number of gateway errors before a host is 
                           ejected from the connection pool.
                         maximum: 4294967295
                         minimum: 0
                         nullable: true
                         type: integer
                       consecutiveLocalOriginFailures:
-                        description: The number of consecutive locally
+                        description: The number of consecutive locally 
                           originated failures before ejection occurs.
                         maximum: 4294967295
                         minimum: 0
                         nullable: true
                         type: integer
                       interval:
-                        description: Time interval between ejection sweep
+                        description: Time interval between ejection sweep 
                           analysis.
                         type: string
                         x-kubernetes-validations:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       maxEjectionPercent:
-                        description: Maximum % of hosts in the load balancing
+                        description: Maximum % of hosts in the load balancing 
                           pool for the upstream service that can be ejected.
                         format: int32
                         type: integer
                       minHealthPercent:
-                        description: Outlier detection will be enabled as long
-                          as the associated load balancing pool has at least
+                        description: Outlier detection will be enabled as long 
+                          as the associated load balancing pool has at least 
                           `minHealthPercent` hosts in healthy mode.
                         format: int32
                         type: integer
                       splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local
+                        description: Determines whether to distinguish local 
                           origin failures from external errors.
                         type: boolean
                     type: object
@@ -4362,8 +4362,8 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of requests that
-                                    will be queued while waiting for a ready
+                                  description: Maximum number of requests that 
+                                    will be queued while waiting for a ready 
                                     connection pool connection.
                                   format: int32
                                   type: integer
@@ -4373,97 +4373,97 @@ spec:
                                   format: int32
                                   type: integer
                                 idleTimeout:
-                                  description: The idle timeout for upstream
+                                  description: The idle timeout for upstream 
                                     connection pool connections.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConcurrentStreams:
-                                  description: The maximum number of concurrent
-                                    streams allowed for a peer on one HTTP/2
+                                  description: The maximum number of concurrent 
+                                    streams allowed for a peer on one HTTP/2 
                                     connection.
                                   format: int32
                                   type: integer
                                 maxRequestsPerConnection:
-                                  description: Maximum number of requests per
+                                  description: Maximum number of requests per 
                                     connection to a backend.
                                   format: int32
                                   type: integer
                                 maxRetries:
-                                  description: Maximum number of retries that
+                                  description: Maximum number of retries that 
                                     can be outstanding to all hosts in a cluster
                                     at a given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
-                                  description: If set to true, client protocol
-                                    will be preserved while initiating
+                                  description: If set to true, client protocol 
+                                    will be preserved while initiating 
                                     connection to backend.
                                   type: boolean
                               type: object
                             tcp:
-                              description: Settings common to both HTTP and TCP
+                              description: Settings common to both HTTP and TCP 
                                 upstream connections.
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 idleTimeout:
-                                  description: The idle timeout for TCP
+                                  description: The idle timeout for TCP 
                                     connections.
                                   type: string
                                 maxConnectionDuration:
-                                  description: The maximum duration of a
+                                  description: The maximum duration of a 
                                     connection.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConnections:
-                                  description: Maximum number of HTTP1 /TCP
+                                  description: Maximum number of HTTP1 /TCP 
                                     connections to a destination host.
                                   format: int32
                                   type: integer
                                 tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on
+                                  description: If set then set SO_KEEPALIVE on 
                                     the socket to enable TCP Keepalives.
                                   properties:
                                     interval:
-                                      description: The time duration between
+                                      description: The time duration between 
                                         keep-alive probes.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                     probes:
-                                      description: Maximum number of keepalive
-                                        probes to send without response before
+                                      description: Maximum number of keepalive 
+                                        probes to send without response before 
                                         deciding the connection is dead.
                                       maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                     time:
-                                      description: The time duration a
-                                        connection needs to be idle before
+                                      description: The time duration a 
+                                        connection needs to be idle before 
                                         keep-alive probes start being sent.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                   type: object
                               type: object
                           type: object
                         loadBalancer:
-                          description: Settings controlling the load balancer
+                          description: Settings controlling the load balancer 
                             algorithms.
                           oneOf:
                           - not:
@@ -4519,11 +4519,11 @@ spec:
                                       items:
                                         properties:
                                           name:
-                                            description: The name of the cookie
+                                            description: The name of the cookie 
                                               attribute.
                                             type: string
                                           value:
-                                            description: The optional value of
+                                            description: The optional value of 
                                               the cookie attribute.
                                             type: string
                                         required:
@@ -4543,20 +4543,20 @@ spec:
                                   - name
                                   type: object
                                 httpHeaderName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     header.
                                   type: string
                                 httpQueryParameterName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     query parameter.
                                   type: string
                                 maglev:
-                                  description: The Maglev load balancer
-                                    implements consistent hashing to backend
+                                  description: The Maglev load balancer 
+                                    implements consistent hashing to backend 
                                     hosts.
                                   properties:
                                     tableSize:
-                                      description: The table size for Maglev
+                                      description: The table size for Maglev 
                                         hashing.
                                       minimum: 0
                                       type: integer
@@ -4566,8 +4566,8 @@ spec:
                                   minimum: 0
                                   type: integer
                                 ringHash:
-                                  description: The ring/modulo hash load
-                                    balancer implements consistent hashing to
+                                  description: The ring/modulo hash load 
+                                    balancer implements consistent hashing to 
                                     backend hosts.
                                   properties:
                                     minimumRingSize:
@@ -4577,7 +4577,7 @@ spec:
                                       type: integer
                                   type: object
                                 useSourceIp:
-                                  description: Hash based on the source IP
+                                  description: Hash based on the source IP 
                                     address.
                                   type: boolean
                               type: object
@@ -4589,7 +4589,7 @@ spec:
                                   items:
                                     properties:
                                       from:
-                                        description: Originating locality, '/'
+                                        description: Originating locality, '/' 
                                           separated, e.g.
                                         type: string
                                       to:
@@ -4597,7 +4597,7 @@ spec:
                                           maximum: 4294967295
                                           minimum: 0
                                           type: integer
-                                        description: Map of upstream localities
+                                        description: Map of upstream localities 
                                           to traffic distribution weights.
                                         type: object
                                     type: object
@@ -4615,16 +4615,16 @@ spec:
                                         description: Originating region.
                                         type: string
                                       to:
-                                        description: Destination region the
-                                          traffic will fail over to when
+                                        description: Destination region the 
+                                          traffic will fail over to when 
                                           endpoints in the 'from' region becomes
                                           unhealthy.
                                         type: string
                                     type: object
                                   type: array
                                 failoverPriority:
-                                  description: failoverPriority is an ordered
-                                    list of labels used to sort endpoints to do
+                                  description: failoverPriority is an ordered 
+                                    list of labels used to sort endpoints to do 
                                     priority based load balancing.
                                   items:
                                     type: string
@@ -4644,12 +4644,12 @@ spec:
                               - LEAST_REQUEST
                               type: string
                             warmup:
-                              description: Represents the warmup configuration
+                              description: Represents the warmup configuration 
                                 of Service.
                               properties:
                                 aggression:
                                   description: This parameter controls the speed
-                                    of traffic increase over the warmup
+                                    of traffic increase over the warmup 
                                     duration.
                                   format: double
                                   minimum: 0
@@ -4658,7 +4658,7 @@ spec:
                                 duration:
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 minimumPercent:
@@ -4674,7 +4674,7 @@ spec:
                               description: 'Deprecated: use `warmup` instead.'
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                           type: object
@@ -4684,7 +4684,7 @@ spec:
                               description: Minimum ejection duration.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             consecutive5xxErrors:
@@ -4698,48 +4698,48 @@ spec:
                               format: int32
                               type: integer
                             consecutiveGatewayErrors:
-                              description: Number of gateway errors before a
+                              description: Number of gateway errors before a 
                                 host is ejected from the connection pool.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally
+                              description: The number of consecutive locally 
                                 originated failures before ejection occurs.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             interval:
-                              description: Time interval between ejection sweep
+                              description: Time interval between ejection sweep 
                                 analysis.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxEjectionPercent:
-                              description: Maximum % of hosts in the load
+                              description: Maximum % of hosts in the load 
                                 balancing pool for the upstream service that can
                                 be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
-                              description: Outlier detection will be enabled as
-                                long as the associated load balancing pool has
-                                at least `minHealthPercent` hosts in healthy
+                              description: Outlier detection will be enabled as 
+                                long as the associated load balancing pool has 
+                                at least `minHealthPercent` hosts in healthy 
                                 mode.
                               format: int32
                               type: integer
                             splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish
+                              description: Determines whether to distinguish 
                                 local origin failures from external errors.
                               type: boolean
                           type: object
                         port:
-                          description: Specifies the number of a port on the
-                            destination service on which this policy is being
+                          description: Specifies the number of a port on the 
+                            destination service on which this policy is being 
                             applied.
                           properties:
                             number:
@@ -4748,7 +4748,7 @@ spec:
                               type: integer
                           type: object
                         tls:
-                          description: TLS related settings for connections to
+                          description: TLS related settings for connections to 
                             the upstream service.
                           properties:
                             caCertificates:
@@ -4766,7 +4766,7 @@ spec:
                               type: string
                             credentialName:
                               description: The name of the secret that holds the
-                                TLS certs for the client including the CA
+                                TLS certs for the client including the CA 
                                 certificates.
                               type: string
                             insecureSkipVerify:
@@ -4791,11 +4791,11 @@ spec:
                               description: REQUIRED if mode is `MUTUAL`.
                               type: string
                             sni:
-                              description: SNI string to present to the server
+                              description: SNI string to present to the server 
                                 during TLS handshake.
                               type: string
                             subjectAltNames:
-                              description: A list of alternate names to verify
+                              description: A list of alternate names to verify 
                                 the subject identity in the certificate.
                               items:
                                 type: string
@@ -4818,18 +4818,18 @@ spec:
                         type: string
                     type: object
                   retryBudget:
-                    description: Specifies a limit on concurrent retries in
+                    description: Specifies a limit on concurrent retries in 
                       relation to the number of active requests.
                     properties:
                       minRetryConcurrency:
-                        description: Specifies the minimum retry concurrency
+                        description: Specifies the minimum retry concurrency 
                           allowed for the retry budget.
                         maximum: 4294967295
                         minimum: 0
                         type: integer
                       percent:
-                        description: Specifies the limit on concurrent retries
-                          as a percentage of the sum of active requests and
+                        description: Specifies the limit on concurrent retries 
+                          as a percentage of the sum of active requests and 
                           active pending requests.
                         format: double
                         maximum: 100
@@ -4838,7 +4838,7 @@ spec:
                         type: number
                     type: object
                   tls:
-                    description: TLS related settings for connections to the
+                    description: TLS related settings for connections to the 
                       upstream service.
                     properties:
                       caCertificates:
@@ -4855,7 +4855,7 @@ spec:
                         description: REQUIRED if mode is `MUTUAL`.
                         type: string
                       credentialName:
-                        description: The name of the secret that holds the TLS
+                        description: The name of the secret that holds the TLS 
                           certs for the client including the CA certificates.
                         type: string
                       insecureSkipVerify:
@@ -4879,31 +4879,31 @@ spec:
                         description: REQUIRED if mode is `MUTUAL`.
                         type: string
                       sni:
-                        description: SNI string to present to the server during
+                        description: SNI string to present to the server during 
                           TLS handshake.
                         type: string
                       subjectAltNames:
-                        description: A list of alternate names to verify the
+                        description: A list of alternate names to verify the 
                           subject identity in the certificate.
                         items:
                           type: string
                         type: array
                     type: object
                   tunnel:
-                    description: Configuration of tunneling TCP over other
+                    description: Configuration of tunneling TCP over other 
                       transport or application layers for the host configured in
                       the DestinationRule.
                     properties:
                       protocol:
-                        description: Specifies which protocol to use for
+                        description: Specifies which protocol to use for 
                           tunneling the downstream connection.
                         type: string
                       targetHost:
-                        description: Specifies a host to which the downstream
+                        description: Specifies a host to which the downstream 
                           connection is tunneled.
                         type: string
                       targetPort:
-                        description: Specifies a port to which the downstream
+                        description: Specifies a port to which the downstream 
                           connection is tunneled.
                         maximum: 4294967295
                         minimum: 0
@@ -4914,8 +4914,8 @@ spec:
                     type: object
                 type: object
               workloadSelector:
-                description: Criteria used to select the specific set of
-                  pods/VMs on which this `DestinationRule` configuration should
+                description: Criteria used to select the specific set of 
+                  pods/VMs on which this `DestinationRule` configuration should 
                   be applied.
                 properties:
                   matchLabels:
@@ -4954,18 +4954,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -5004,12 +5004,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -5028,11 +5028,11 @@ spec:
       name: Host
       type: string
     - description: CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in
-        happens-before order across separate operations. Clients may not set
-        this value. It is represented in RFC3339 form and is in UTC. Populated
-        by the system. Read-only. Null for lists. For more information, see
-        [Kubernetes API
+        when this object was created. It is not guaranteed to be set in 
+        happens-before order across separate operations. Clients may not set 
+        this value. It is represented in RFC3339 form and is in UTC. Populated 
+        by the system. Read-only. Null for lists. For more information, see 
+        [Kubernetes API 
         Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -5055,7 +5055,7 @@ spec:
                 description: The name of a service from the service registry.
                 type: string
               subsets:
-                description: One or more named sets that represent individual
+                description: One or more named sets that represent individual 
                   versions of a service.
                 items:
                   properties:
@@ -5087,8 +5087,8 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of requests that
-                                    will be queued while waiting for a ready
+                                  description: Maximum number of requests that 
+                                    will be queued while waiting for a ready 
                                     connection pool connection.
                                   format: int32
                                   type: integer
@@ -5098,97 +5098,97 @@ spec:
                                   format: int32
                                   type: integer
                                 idleTimeout:
-                                  description: The idle timeout for upstream
+                                  description: The idle timeout for upstream 
                                     connection pool connections.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConcurrentStreams:
-                                  description: The maximum number of concurrent
-                                    streams allowed for a peer on one HTTP/2
+                                  description: The maximum number of concurrent 
+                                    streams allowed for a peer on one HTTP/2 
                                     connection.
                                   format: int32
                                   type: integer
                                 maxRequestsPerConnection:
-                                  description: Maximum number of requests per
+                                  description: Maximum number of requests per 
                                     connection to a backend.
                                   format: int32
                                   type: integer
                                 maxRetries:
-                                  description: Maximum number of retries that
+                                  description: Maximum number of retries that 
                                     can be outstanding to all hosts in a cluster
                                     at a given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
-                                  description: If set to true, client protocol
-                                    will be preserved while initiating
+                                  description: If set to true, client protocol 
+                                    will be preserved while initiating 
                                     connection to backend.
                                   type: boolean
                               type: object
                             tcp:
-                              description: Settings common to both HTTP and TCP
+                              description: Settings common to both HTTP and TCP 
                                 upstream connections.
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 idleTimeout:
-                                  description: The idle timeout for TCP
+                                  description: The idle timeout for TCP 
                                     connections.
                                   type: string
                                 maxConnectionDuration:
-                                  description: The maximum duration of a
+                                  description: The maximum duration of a 
                                     connection.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConnections:
-                                  description: Maximum number of HTTP1 /TCP
+                                  description: Maximum number of HTTP1 /TCP 
                                     connections to a destination host.
                                   format: int32
                                   type: integer
                                 tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on
+                                  description: If set then set SO_KEEPALIVE on 
                                     the socket to enable TCP Keepalives.
                                   properties:
                                     interval:
-                                      description: The time duration between
+                                      description: The time duration between 
                                         keep-alive probes.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                     probes:
-                                      description: Maximum number of keepalive
-                                        probes to send without response before
+                                      description: Maximum number of keepalive 
+                                        probes to send without response before 
                                         deciding the connection is dead.
                                       maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                     time:
-                                      description: The time duration a
-                                        connection needs to be idle before
+                                      description: The time duration a 
+                                        connection needs to be idle before 
                                         keep-alive probes start being sent.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                   type: object
                               type: object
                           type: object
                         loadBalancer:
-                          description: Settings controlling the load balancer
+                          description: Settings controlling the load balancer 
                             algorithms.
                           oneOf:
                           - not:
@@ -5244,11 +5244,11 @@ spec:
                                       items:
                                         properties:
                                           name:
-                                            description: The name of the cookie
+                                            description: The name of the cookie 
                                               attribute.
                                             type: string
                                           value:
-                                            description: The optional value of
+                                            description: The optional value of 
                                               the cookie attribute.
                                             type: string
                                         required:
@@ -5268,20 +5268,20 @@ spec:
                                   - name
                                   type: object
                                 httpHeaderName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     header.
                                   type: string
                                 httpQueryParameterName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     query parameter.
                                   type: string
                                 maglev:
-                                  description: The Maglev load balancer
-                                    implements consistent hashing to backend
+                                  description: The Maglev load balancer 
+                                    implements consistent hashing to backend 
                                     hosts.
                                   properties:
                                     tableSize:
-                                      description: The table size for Maglev
+                                      description: The table size for Maglev 
                                         hashing.
                                       minimum: 0
                                       type: integer
@@ -5291,8 +5291,8 @@ spec:
                                   minimum: 0
                                   type: integer
                                 ringHash:
-                                  description: The ring/modulo hash load
-                                    balancer implements consistent hashing to
+                                  description: The ring/modulo hash load 
+                                    balancer implements consistent hashing to 
                                     backend hosts.
                                   properties:
                                     minimumRingSize:
@@ -5302,7 +5302,7 @@ spec:
                                       type: integer
                                   type: object
                                 useSourceIp:
-                                  description: Hash based on the source IP
+                                  description: Hash based on the source IP 
                                     address.
                                   type: boolean
                               type: object
@@ -5314,7 +5314,7 @@ spec:
                                   items:
                                     properties:
                                       from:
-                                        description: Originating locality, '/'
+                                        description: Originating locality, '/' 
                                           separated, e.g.
                                         type: string
                                       to:
@@ -5322,7 +5322,7 @@ spec:
                                           maximum: 4294967295
                                           minimum: 0
                                           type: integer
-                                        description: Map of upstream localities
+                                        description: Map of upstream localities 
                                           to traffic distribution weights.
                                         type: object
                                     type: object
@@ -5340,16 +5340,16 @@ spec:
                                         description: Originating region.
                                         type: string
                                       to:
-                                        description: Destination region the
-                                          traffic will fail over to when
+                                        description: Destination region the 
+                                          traffic will fail over to when 
                                           endpoints in the 'from' region becomes
                                           unhealthy.
                                         type: string
                                     type: object
                                   type: array
                                 failoverPriority:
-                                  description: failoverPriority is an ordered
-                                    list of labels used to sort endpoints to do
+                                  description: failoverPriority is an ordered 
+                                    list of labels used to sort endpoints to do 
                                     priority based load balancing.
                                   items:
                                     type: string
@@ -5369,12 +5369,12 @@ spec:
                               - LEAST_REQUEST
                               type: string
                             warmup:
-                              description: Represents the warmup configuration
+                              description: Represents the warmup configuration 
                                 of Service.
                               properties:
                                 aggression:
                                   description: This parameter controls the speed
-                                    of traffic increase over the warmup
+                                    of traffic increase over the warmup 
                                     duration.
                                   format: double
                                   minimum: 0
@@ -5383,7 +5383,7 @@ spec:
                                 duration:
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 minimumPercent:
@@ -5399,7 +5399,7 @@ spec:
                               description: 'Deprecated: use `warmup` instead.'
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                           type: object
@@ -5409,7 +5409,7 @@ spec:
                               description: Minimum ejection duration.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             consecutive5xxErrors:
@@ -5423,47 +5423,47 @@ spec:
                               format: int32
                               type: integer
                             consecutiveGatewayErrors:
-                              description: Number of gateway errors before a
+                              description: Number of gateway errors before a 
                                 host is ejected from the connection pool.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally
+                              description: The number of consecutive locally 
                                 originated failures before ejection occurs.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             interval:
-                              description: Time interval between ejection sweep
+                              description: Time interval between ejection sweep 
                                 analysis.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxEjectionPercent:
-                              description: Maximum % of hosts in the load
+                              description: Maximum % of hosts in the load 
                                 balancing pool for the upstream service that can
                                 be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
-                              description: Outlier detection will be enabled as
-                                long as the associated load balancing pool has
-                                at least `minHealthPercent` hosts in healthy
+                              description: Outlier detection will be enabled as 
+                                long as the associated load balancing pool has 
+                                at least `minHealthPercent` hosts in healthy 
                                 mode.
                               format: int32
                               type: integer
                             splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish
+                              description: Determines whether to distinguish 
                                 local origin failures from external errors.
                               type: boolean
                           type: object
                         portLevelSettings:
-                          description: Traffic policies specific to individual
+                          description: Traffic policies specific to individual 
                             ports.
                           items:
                             properties:
@@ -5483,117 +5483,117 @@ spec:
                                         - UPGRADE
                                         type: string
                                       http1MaxPendingRequests:
-                                        description: Maximum number of requests
-                                          that will be queued while waiting for
+                                        description: Maximum number of requests 
+                                          that will be queued while waiting for 
                                           a ready connection pool connection.
                                         format: int32
                                         type: integer
                                       http2MaxRequests:
-                                        description: Maximum number of active
+                                        description: Maximum number of active 
                                           requests to a destination.
                                         format: int32
                                         type: integer
                                       idleTimeout:
-                                        description: The idle timeout for
+                                        description: The idle timeout for 
                                           upstream connection pool connections.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       maxConcurrentStreams:
-                                        description: The maximum number of
-                                          concurrent streams allowed for a peer
+                                        description: The maximum number of 
+                                          concurrent streams allowed for a peer 
                                           on one HTTP/2 connection.
                                         format: int32
                                         type: integer
                                       maxRequestsPerConnection:
-                                        description: Maximum number of requests
+                                        description: Maximum number of requests 
                                           per connection to a backend.
                                         format: int32
                                         type: integer
                                       maxRetries:
-                                        description: Maximum number of retries
-                                          that can be outstanding to all hosts
+                                        description: Maximum number of retries 
+                                          that can be outstanding to all hosts 
                                           in a cluster at a given time.
                                         format: int32
                                         type: integer
                                       useClientProtocol:
-                                        description: If set to true, client
-                                          protocol will be preserved while
+                                        description: If set to true, client 
+                                          protocol will be preserved while 
                                           initiating connection to backend.
                                         type: boolean
                                     type: object
                                   tcp:
-                                    description: Settings common to both HTTP
+                                    description: Settings common to both HTTP 
                                       and TCP upstream connections.
                                     properties:
                                       connectTimeout:
                                         description: TCP connection timeout.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       idleTimeout:
-                                        description: The idle timeout for TCP
+                                        description: The idle timeout for TCP 
                                           connections.
                                         type: string
                                       maxConnectionDuration:
-                                        description: The maximum duration of a
+                                        description: The maximum duration of a 
                                           connection.
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       maxConnections:
-                                        description: Maximum number of HTTP1
-                                          /TCP connections to a destination
+                                        description: Maximum number of HTTP1 
+                                          /TCP connections to a destination 
                                           host.
                                         format: int32
                                         type: integer
                                       tcpKeepalive:
-                                        description: If set then set
-                                          SO_KEEPALIVE on the socket to enable
+                                        description: If set then set 
+                                          SO_KEEPALIVE on the socket to enable 
                                           TCP Keepalives.
                                         properties:
                                           interval:
-                                            description: The time duration
+                                            description: The time duration 
                                               between keep-alive probes.
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: must be a valid duration
+                                            - message: must be a valid duration 
                                                 greater than 1ms
-                                              rule: duration(self) >=
+                                              rule: duration(self) >= 
                                                 duration('1ms')
                                           probes:
-                                            description: Maximum number of
-                                              keepalive probes to send without
-                                              response before deciding the
+                                            description: Maximum number of 
+                                              keepalive probes to send without 
+                                              response before deciding the 
                                               connection is dead.
                                             maximum: 4294967295
                                             minimum: 0
                                             type: integer
                                           time:
-                                            description: The time duration a
+                                            description: The time duration a 
                                               connection needs to be idle before
-                                              keep-alive probes start being
+                                              keep-alive probes start being 
                                               sent.
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: must be a valid duration
+                                            - message: must be a valid duration 
                                                 greater than 1ms
-                                              rule: duration(self) >=
+                                              rule: duration(self) >= 
                                                 duration('1ms')
                                         type: object
                                     type: object
                                 type: object
                               loadBalancer:
-                                description: Settings controlling the load
+                                description: Settings controlling the load 
                                   balancer algorithms.
                                 oneOf:
                                 - not:
@@ -5644,17 +5644,17 @@ spec:
                                         description: Hash based on HTTP cookie.
                                         properties:
                                           attributes:
-                                            description: Additional attributes
+                                            description: Additional attributes 
                                               for the cookie.
                                             items:
                                               properties:
                                                 name:
-                                                  description: The name of the
+                                                  description: The name of the 
                                                     cookie attribute.
                                                   type: string
                                                 value:
-                                                  description: The optional
-                                                    value of the cookie
+                                                  description: The optional 
+                                                    value of the cookie 
                                                     attribute.
                                                   type: string
                                               required:
@@ -5665,7 +5665,7 @@ spec:
                                             description: Name of the cookie.
                                             type: string
                                           path:
-                                            description: Path to set for the
+                                            description: Path to set for the 
                                               cookie.
                                             type: string
                                           ttl:
@@ -5675,20 +5675,20 @@ spec:
                                         - name
                                         type: object
                                       httpHeaderName:
-                                        description: Hash based on a specific
+                                        description: Hash based on a specific 
                                           HTTP header.
                                         type: string
                                       httpQueryParameterName:
-                                        description: Hash based on a specific
+                                        description: Hash based on a specific 
                                           HTTP query parameter.
                                         type: string
                                       maglev:
-                                        description: The Maglev load balancer
-                                          implements consistent hashing to
+                                        description: The Maglev load balancer 
+                                          implements consistent hashing to 
                                           backend hosts.
                                         properties:
                                           tableSize:
-                                            description: The table size for
+                                            description: The table size for 
                                               Maglev hashing.
                                             minimum: 0
                                             type: integer
@@ -5698,13 +5698,13 @@ spec:
                                         minimum: 0
                                         type: integer
                                       ringHash:
-                                        description: The ring/modulo hash load
+                                        description: The ring/modulo hash load 
                                           balancer implements consistent hashing
                                           to backend hosts.
                                         properties:
                                           minimumRingSize:
-                                            description: The minimum number of
-                                              virtual nodes to use for the hash
+                                            description: The minimum number of 
+                                              virtual nodes to use for the hash 
                                               ring.
                                             minimum: 0
                                             type: integer
@@ -5730,14 +5730,14 @@ spec:
                                                 maximum: 4294967295
                                                 minimum: 0
                                                 type: integer
-                                              description: Map of upstream
-                                                localities to traffic
+                                              description: Map of upstream 
+                                                localities to traffic 
                                                 distribution weights.
                                               type: object
                                           type: object
                                         type: array
                                       enabled:
-                                        description: Enable locality load
+                                        description: Enable locality load 
                                           balancing.
                                         nullable: true
                                         type: boolean
@@ -5750,17 +5750,17 @@ spec:
                                               description: Originating region.
                                               type: string
                                             to:
-                                              description: Destination region
-                                                the traffic will fail over to
-                                                when endpoints in the 'from'
+                                              description: Destination region 
+                                                the traffic will fail over to 
+                                                when endpoints in the 'from' 
                                                 region becomes unhealthy.
                                               type: string
                                           type: object
                                         type: array
                                       failoverPriority:
-                                        description: failoverPriority is an
-                                          ordered list of labels used to sort
-                                          endpoints to do priority based load
+                                        description: failoverPriority is an 
+                                          ordered list of labels used to sort 
+                                          endpoints to do priority based load 
                                           balancing.
                                         items:
                                           type: string
@@ -5780,12 +5780,12 @@ spec:
                                     - LEAST_REQUEST
                                     type: string
                                   warmup:
-                                    description: Represents the warmup
+                                    description: Represents the warmup 
                                       configuration of Service.
                                     properties:
                                       aggression:
                                         description: This parameter controls the
-                                          speed of traffic increase over the
+                                          speed of traffic increase over the 
                                           warmup duration.
                                         format: double
                                         minimum: 0
@@ -5794,9 +5794,9 @@ spec:
                                       duration:
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: must be a valid duration
+                                        - message: must be a valid duration 
                                             greater than 1ms
-                                          rule: duration(self) >=
+                                          rule: duration(self) >= 
                                             duration('1ms')
                                       minimumPercent:
                                         format: double
@@ -5811,7 +5811,7 @@ spec:
                                     description: 'Deprecated: use `warmup` instead.'
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                 type: object
@@ -5821,11 +5821,11 @@ spec:
                                     description: Minimum ejection duration.
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                   consecutive5xxErrors:
-                                    description: Number of 5xx errors before a
+                                    description: Number of 5xx errors before a 
                                       host is ejected from the connection pool.
                                     maximum: 4294967295
                                     minimum: 0
@@ -5836,50 +5836,50 @@ spec:
                                     type: integer
                                   consecutiveGatewayErrors:
                                     description: Number of gateway errors before
-                                      a host is ejected from the connection
+                                      a host is ejected from the connection 
                                       pool.
                                     maximum: 4294967295
                                     minimum: 0
                                     nullable: true
                                     type: integer
                                   consecutiveLocalOriginFailures:
-                                    description: The number of consecutive
-                                      locally originated failures before
+                                    description: The number of consecutive 
+                                      locally originated failures before 
                                       ejection occurs.
                                     maximum: 4294967295
                                     minimum: 0
                                     nullable: true
                                     type: integer
                                   interval:
-                                    description: Time interval between ejection
+                                    description: Time interval between ejection 
                                       sweep analysis.
                                     type: string
                                     x-kubernetes-validations:
-                                    - message: must be a valid duration greater
+                                    - message: must be a valid duration greater 
                                         than 1ms
                                       rule: duration(self) >= duration('1ms')
                                   maxEjectionPercent:
-                                    description: Maximum % of hosts in the load
-                                      balancing pool for the upstream service
+                                    description: Maximum % of hosts in the load 
+                                      balancing pool for the upstream service 
                                       that can be ejected.
                                     format: int32
                                     type: integer
                                   minHealthPercent:
-                                    description: Outlier detection will be
-                                      enabled as long as the associated load
-                                      balancing pool has at least
+                                    description: Outlier detection will be 
+                                      enabled as long as the associated load 
+                                      balancing pool has at least 
                                       `minHealthPercent` hosts in healthy mode.
                                     format: int32
                                     type: integer
                                   splitExternalLocalOriginErrors:
-                                    description: Determines whether to
-                                      distinguish local origin failures from
+                                    description: Determines whether to 
+                                      distinguish local origin failures from 
                                       external errors.
                                     type: boolean
                                 type: object
                               port:
-                                description: Specifies the number of a port on
-                                  the destination service on which this policy
+                                description: Specifies the number of a port on 
+                                  the destination service on which this policy 
                                   is being applied.
                                 properties:
                                   number:
@@ -5888,7 +5888,7 @@ spec:
                                     type: integer
                                 type: object
                               tls:
-                                description: TLS related settings for
+                                description: TLS related settings for 
                                   connections to the upstream service.
                                 properties:
                                   caCertificates:
@@ -5905,8 +5905,8 @@ spec:
                                     description: REQUIRED if mode is `MUTUAL`.
                                     type: string
                                   credentialName:
-                                    description: The name of the secret that
-                                      holds the TLS certs for the client
+                                    description: The name of the secret that 
+                                      holds the TLS certs for the client 
                                       including the CA certificates.
                                     type: string
                                   insecureSkipVerify:
@@ -5931,12 +5931,12 @@ spec:
                                     description: REQUIRED if mode is `MUTUAL`.
                                     type: string
                                   sni:
-                                    description: SNI string to present to the
+                                    description: SNI string to present to the 
                                       server during TLS handshake.
                                     type: string
                                   subjectAltNames:
-                                    description: A list of alternate names to
-                                      verify the subject identity in the
+                                    description: A list of alternate names to 
+                                      verify the subject identity in the 
                                       certificate.
                                     items:
                                       type: string
@@ -5959,18 +5959,18 @@ spec:
                               type: string
                           type: object
                         retryBudget:
-                          description: Specifies a limit on concurrent retries
+                          description: Specifies a limit on concurrent retries 
                             in relation to the number of active requests.
                           properties:
                             minRetryConcurrency:
-                              description: Specifies the minimum retry
+                              description: Specifies the minimum retry 
                                 concurrency allowed for the retry budget.
                               maximum: 4294967295
                               minimum: 0
                               type: integer
                             percent:
-                              description: Specifies the limit on concurrent
-                                retries as a percentage of the sum of active
+                              description: Specifies the limit on concurrent 
+                                retries as a percentage of the sum of active 
                                 requests and active pending requests.
                               format: double
                               maximum: 100
@@ -5979,7 +5979,7 @@ spec:
                               type: number
                           type: object
                         tls:
-                          description: TLS related settings for connections to
+                          description: TLS related settings for connections to 
                             the upstream service.
                           properties:
                             caCertificates:
@@ -5997,7 +5997,7 @@ spec:
                               type: string
                             credentialName:
                               description: The name of the secret that holds the
-                                TLS certs for the client including the CA
+                                TLS certs for the client including the CA 
                                 certificates.
                               type: string
                             insecureSkipVerify:
@@ -6022,11 +6022,11 @@ spec:
                               description: REQUIRED if mode is `MUTUAL`.
                               type: string
                             sni:
-                              description: SNI string to present to the server
+                              description: SNI string to present to the server 
                                 during TLS handshake.
                               type: string
                             subjectAltNames:
-                              description: A list of alternate names to verify
+                              description: A list of alternate names to verify 
                                 the subject identity in the certificate.
                               items:
                                 type: string
@@ -6034,19 +6034,19 @@ spec:
                           type: object
                         tunnel:
                           description: Configuration of tunneling TCP over other
-                            transport or application layers for the host
+                            transport or application layers for the host 
                             configured in the DestinationRule.
                           properties:
                             protocol:
-                              description: Specifies which protocol to use for
+                              description: Specifies which protocol to use for 
                                 tunneling the downstream connection.
                               type: string
                             targetHost:
-                              description: Specifies a host to which the
+                              description: Specifies a host to which the 
                                 downstream connection is tunneled.
                               type: string
                             targetPort:
-                              description: Specifies a port to which the
+                              description: Specifies a port to which the 
                                 downstream connection is tunneled.
                               maximum: 4294967295
                               minimum: 0
@@ -6061,7 +6061,7 @@ spec:
                   type: object
                 type: array
               trafficPolicy:
-                description: Traffic policies to apply (load balancing policy,
+                description: Traffic policies to apply (load balancing policy, 
                   connection pool sizes, outlier detection).
                 properties:
                   connectionPool:
@@ -6081,36 +6081,36 @@ spec:
                             type: string
                           http1MaxPendingRequests:
                             description: Maximum number of requests that will be
-                              queued while waiting for a ready connection pool
+                              queued while waiting for a ready connection pool 
                               connection.
                             format: int32
                             type: integer
                           http2MaxRequests:
-                            description: Maximum number of active requests to a
+                            description: Maximum number of active requests to a 
                               destination.
                             format: int32
                             type: integer
                           idleTimeout:
-                            description: The idle timeout for upstream
+                            description: The idle timeout for upstream 
                               connection pool connections.
                             type: string
                             x-kubernetes-validations:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           maxConcurrentStreams:
-                            description: The maximum number of concurrent
-                              streams allowed for a peer on one HTTP/2
+                            description: The maximum number of concurrent 
+                              streams allowed for a peer on one HTTP/2 
                               connection.
                             format: int32
                             type: integer
                           maxRequestsPerConnection:
-                            description: Maximum number of requests per
+                            description: Maximum number of requests per 
                               connection to a backend.
                             format: int32
                             type: integer
                           maxRetries:
-                            description: Maximum number of retries that can be
-                              outstanding to all hosts in a cluster at a given
+                            description: Maximum number of retries that can be 
+                              outstanding to all hosts in a cluster at a given 
                               time.
                             format: int32
                             type: integer
@@ -6120,7 +6120,7 @@ spec:
                             type: boolean
                         type: object
                       tcp:
-                        description: Settings common to both HTTP and TCP
+                        description: Settings common to both HTTP and TCP 
                           upstream connections.
                         properties:
                           connectTimeout:
@@ -6139,16 +6139,16 @@ spec:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           maxConnections:
-                            description: Maximum number of HTTP1 /TCP
+                            description: Maximum number of HTTP1 /TCP 
                               connections to a destination host.
                             format: int32
                             type: integer
                           tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the
+                            description: If set then set SO_KEEPALIVE on the 
                               socket to enable TCP Keepalives.
                             properties:
                               interval:
-                                description: The time duration between
+                                description: The time duration between 
                                   keep-alive probes.
                                 type: string
                                 x-kubernetes-validations:
@@ -6156,15 +6156,15 @@ spec:
                                     1ms
                                   rule: duration(self) >= duration('1ms')
                               probes:
-                                description: Maximum number of keepalive probes
-                                  to send without response before deciding the
+                                description: Maximum number of keepalive probes 
+                                  to send without response before deciding the 
                                   connection is dead.
                                 maximum: 4294967295
                                 minimum: 0
                                 type: integer
                               time:
-                                description: The time duration a connection
-                                  needs to be idle before keep-alive probes
+                                description: The time duration a connection 
+                                  needs to be idle before keep-alive probes 
                                   start being sent.
                                 type: string
                                 x-kubernetes-validations:
@@ -6175,7 +6175,7 @@ spec:
                         type: object
                     type: object
                   loadBalancer:
-                    description: Settings controlling the load balancer
+                    description: Settings controlling the load balancer 
                       algorithms.
                     oneOf:
                     - not:
@@ -6226,16 +6226,16 @@ spec:
                             description: Hash based on HTTP cookie.
                             properties:
                               attributes:
-                                description: Additional attributes for the
+                                description: Additional attributes for the 
                                   cookie.
                                 items:
                                   properties:
                                     name:
-                                      description: The name of the cookie
+                                      description: The name of the cookie 
                                         attribute.
                                       type: string
                                     value:
-                                      description: The optional value of the
+                                      description: The optional value of the 
                                         cookie attribute.
                                       type: string
                                   required:
@@ -6258,11 +6258,11 @@ spec:
                             description: Hash based on a specific HTTP header.
                             type: string
                           httpQueryParameterName:
-                            description: Hash based on a specific HTTP query
+                            description: Hash based on a specific HTTP query 
                               parameter.
                             type: string
                           maglev:
-                            description: The Maglev load balancer implements
+                            description: The Maglev load balancer implements 
                               consistent hashing to backend hosts.
                             properties:
                               tableSize:
@@ -6275,7 +6275,7 @@ spec:
                             minimum: 0
                             type: integer
                           ringHash:
-                            description: The ring/modulo hash load balancer
+                            description: The ring/modulo hash load balancer 
                               implements consistent hashing to backend hosts.
                             properties:
                               minimumRingSize:
@@ -6296,7 +6296,7 @@ spec:
                             items:
                               properties:
                                 from:
-                                  description: Originating locality, '/'
+                                  description: Originating locality, '/' 
                                     separated, e.g.
                                   type: string
                                 to:
@@ -6304,7 +6304,7 @@ spec:
                                     maximum: 4294967295
                                     minimum: 0
                                     type: integer
-                                  description: Map of upstream localities to
+                                  description: Map of upstream localities to 
                                     traffic distribution weights.
                                   type: object
                               type: object
@@ -6322,14 +6322,14 @@ spec:
                                   description: Originating region.
                                   type: string
                                 to:
-                                  description: Destination region the traffic
-                                    will fail over to when endpoints in the
+                                  description: Destination region the traffic 
+                                    will fail over to when endpoints in the 
                                     'from' region becomes unhealthy.
                                   type: string
                               type: object
                             type: array
                           failoverPriority:
-                            description: failoverPriority is an ordered list of
+                            description: failoverPriority is an ordered list of 
                               labels used to sort endpoints to do priority based
                               load balancing.
                             items:
@@ -6350,11 +6350,11 @@ spec:
                         - LEAST_REQUEST
                         type: string
                       warmup:
-                        description: Represents the warmup configuration of
+                        description: Represents the warmup configuration of 
                           Service.
                         properties:
                           aggression:
-                            description: This parameter controls the speed of
+                            description: This parameter controls the speed of 
                               traffic increase over the warmup duration.
                             format: double
                             minimum: 0
@@ -6390,7 +6390,7 @@ spec:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is
+                        description: Number of 5xx errors before a host is 
                           ejected from the connection pool.
                         maximum: 4294967295
                         minimum: 0
@@ -6400,39 +6400,39 @@ spec:
                         format: int32
                         type: integer
                       consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is
+                        description: Number of gateway errors before a host is 
                           ejected from the connection pool.
                         maximum: 4294967295
                         minimum: 0
                         nullable: true
                         type: integer
                       consecutiveLocalOriginFailures:
-                        description: The number of consecutive locally
+                        description: The number of consecutive locally 
                           originated failures before ejection occurs.
                         maximum: 4294967295
                         minimum: 0
                         nullable: true
                         type: integer
                       interval:
-                        description: Time interval between ejection sweep
+                        description: Time interval between ejection sweep 
                           analysis.
                         type: string
                         x-kubernetes-validations:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       maxEjectionPercent:
-                        description: Maximum % of hosts in the load balancing
+                        description: Maximum % of hosts in the load balancing 
                           pool for the upstream service that can be ejected.
                         format: int32
                         type: integer
                       minHealthPercent:
-                        description: Outlier detection will be enabled as long
-                          as the associated load balancing pool has at least
+                        description: Outlier detection will be enabled as long 
+                          as the associated load balancing pool has at least 
                           `minHealthPercent` hosts in healthy mode.
                         format: int32
                         type: integer
                       splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local
+                        description: Determines whether to distinguish local 
                           origin failures from external errors.
                         type: boolean
                     type: object
@@ -6456,8 +6456,8 @@ spec:
                                   - UPGRADE
                                   type: string
                                 http1MaxPendingRequests:
-                                  description: Maximum number of requests that
-                                    will be queued while waiting for a ready
+                                  description: Maximum number of requests that 
+                                    will be queued while waiting for a ready 
                                     connection pool connection.
                                   format: int32
                                   type: integer
@@ -6467,97 +6467,97 @@ spec:
                                   format: int32
                                   type: integer
                                 idleTimeout:
-                                  description: The idle timeout for upstream
+                                  description: The idle timeout for upstream 
                                     connection pool connections.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConcurrentStreams:
-                                  description: The maximum number of concurrent
-                                    streams allowed for a peer on one HTTP/2
+                                  description: The maximum number of concurrent 
+                                    streams allowed for a peer on one HTTP/2 
                                     connection.
                                   format: int32
                                   type: integer
                                 maxRequestsPerConnection:
-                                  description: Maximum number of requests per
+                                  description: Maximum number of requests per 
                                     connection to a backend.
                                   format: int32
                                   type: integer
                                 maxRetries:
-                                  description: Maximum number of retries that
+                                  description: Maximum number of retries that 
                                     can be outstanding to all hosts in a cluster
                                     at a given time.
                                   format: int32
                                   type: integer
                                 useClientProtocol:
-                                  description: If set to true, client protocol
-                                    will be preserved while initiating
+                                  description: If set to true, client protocol 
+                                    will be preserved while initiating 
                                     connection to backend.
                                   type: boolean
                               type: object
                             tcp:
-                              description: Settings common to both HTTP and TCP
+                              description: Settings common to both HTTP and TCP 
                                 upstream connections.
                               properties:
                                 connectTimeout:
                                   description: TCP connection timeout.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 idleTimeout:
-                                  description: The idle timeout for TCP
+                                  description: The idle timeout for TCP 
                                     connections.
                                   type: string
                                 maxConnectionDuration:
-                                  description: The maximum duration of a
+                                  description: The maximum duration of a 
                                     connection.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 maxConnections:
-                                  description: Maximum number of HTTP1 /TCP
+                                  description: Maximum number of HTTP1 /TCP 
                                     connections to a destination host.
                                   format: int32
                                   type: integer
                                 tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on
+                                  description: If set then set SO_KEEPALIVE on 
                                     the socket to enable TCP Keepalives.
                                   properties:
                                     interval:
-                                      description: The time duration between
+                                      description: The time duration between 
                                         keep-alive probes.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                     probes:
-                                      description: Maximum number of keepalive
-                                        probes to send without response before
+                                      description: Maximum number of keepalive 
+                                        probes to send without response before 
                                         deciding the connection is dead.
                                       maximum: 4294967295
                                       minimum: 0
                                       type: integer
                                     time:
-                                      description: The time duration a
-                                        connection needs to be idle before
+                                      description: The time duration a 
+                                        connection needs to be idle before 
                                         keep-alive probes start being sent.
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: must be a valid duration
+                                      - message: must be a valid duration 
                                           greater than 1ms
                                         rule: duration(self) >= duration('1ms')
                                   type: object
                               type: object
                           type: object
                         loadBalancer:
-                          description: Settings controlling the load balancer
+                          description: Settings controlling the load balancer 
                             algorithms.
                           oneOf:
                           - not:
@@ -6613,11 +6613,11 @@ spec:
                                       items:
                                         properties:
                                           name:
-                                            description: The name of the cookie
+                                            description: The name of the cookie 
                                               attribute.
                                             type: string
                                           value:
-                                            description: The optional value of
+                                            description: The optional value of 
                                               the cookie attribute.
                                             type: string
                                         required:
@@ -6637,20 +6637,20 @@ spec:
                                   - name
                                   type: object
                                 httpHeaderName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     header.
                                   type: string
                                 httpQueryParameterName:
-                                  description: Hash based on a specific HTTP
+                                  description: Hash based on a specific HTTP 
                                     query parameter.
                                   type: string
                                 maglev:
-                                  description: The Maglev load balancer
-                                    implements consistent hashing to backend
+                                  description: The Maglev load balancer 
+                                    implements consistent hashing to backend 
                                     hosts.
                                   properties:
                                     tableSize:
-                                      description: The table size for Maglev
+                                      description: The table size for Maglev 
                                         hashing.
                                       minimum: 0
                                       type: integer
@@ -6660,8 +6660,8 @@ spec:
                                   minimum: 0
                                   type: integer
                                 ringHash:
-                                  description: The ring/modulo hash load
-                                    balancer implements consistent hashing to
+                                  description: The ring/modulo hash load 
+                                    balancer implements consistent hashing to 
                                     backend hosts.
                                   properties:
                                     minimumRingSize:
@@ -6671,7 +6671,7 @@ spec:
                                       type: integer
                                   type: object
                                 useSourceIp:
-                                  description: Hash based on the source IP
+                                  description: Hash based on the source IP 
                                     address.
                                   type: boolean
                               type: object
@@ -6683,7 +6683,7 @@ spec:
                                   items:
                                     properties:
                                       from:
-                                        description: Originating locality, '/'
+                                        description: Originating locality, '/' 
                                           separated, e.g.
                                         type: string
                                       to:
@@ -6691,7 +6691,7 @@ spec:
                                           maximum: 4294967295
                                           minimum: 0
                                           type: integer
-                                        description: Map of upstream localities
+                                        description: Map of upstream localities 
                                           to traffic distribution weights.
                                         type: object
                                     type: object
@@ -6709,16 +6709,16 @@ spec:
                                         description: Originating region.
                                         type: string
                                       to:
-                                        description: Destination region the
-                                          traffic will fail over to when
+                                        description: Destination region the 
+                                          traffic will fail over to when 
                                           endpoints in the 'from' region becomes
                                           unhealthy.
                                         type: string
                                     type: object
                                   type: array
                                 failoverPriority:
-                                  description: failoverPriority is an ordered
-                                    list of labels used to sort endpoints to do
+                                  description: failoverPriority is an ordered 
+                                    list of labels used to sort endpoints to do 
                                     priority based load balancing.
                                   items:
                                     type: string
@@ -6738,12 +6738,12 @@ spec:
                               - LEAST_REQUEST
                               type: string
                             warmup:
-                              description: Represents the warmup configuration
+                              description: Represents the warmup configuration 
                                 of Service.
                               properties:
                                 aggression:
                                   description: This parameter controls the speed
-                                    of traffic increase over the warmup
+                                    of traffic increase over the warmup 
                                     duration.
                                   format: double
                                   minimum: 0
@@ -6752,7 +6752,7 @@ spec:
                                 duration:
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 minimumPercent:
@@ -6768,7 +6768,7 @@ spec:
                               description: 'Deprecated: use `warmup` instead.'
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                           type: object
@@ -6778,7 +6778,7 @@ spec:
                               description: Minimum ejection duration.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             consecutive5xxErrors:
@@ -6792,48 +6792,48 @@ spec:
                               format: int32
                               type: integer
                             consecutiveGatewayErrors:
-                              description: Number of gateway errors before a
+                              description: Number of gateway errors before a 
                                 host is ejected from the connection pool.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally
+                              description: The number of consecutive locally 
                                 originated failures before ejection occurs.
                               maximum: 4294967295
                               minimum: 0
                               nullable: true
                               type: integer
                             interval:
-                              description: Time interval between ejection sweep
+                              description: Time interval between ejection sweep 
                                 analysis.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxEjectionPercent:
-                              description: Maximum % of hosts in the load
+                              description: Maximum % of hosts in the load 
                                 balancing pool for the upstream service that can
                                 be ejected.
                               format: int32
                               type: integer
                             minHealthPercent:
-                              description: Outlier detection will be enabled as
-                                long as the associated load balancing pool has
-                                at least `minHealthPercent` hosts in healthy
+                              description: Outlier detection will be enabled as 
+                                long as the associated load balancing pool has 
+                                at least `minHealthPercent` hosts in healthy 
                                 mode.
                               format: int32
                               type: integer
                             splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish
+                              description: Determines whether to distinguish 
                                 local origin failures from external errors.
                               type: boolean
                           type: object
                         port:
-                          description: Specifies the number of a port on the
-                            destination service on which this policy is being
+                          description: Specifies the number of a port on the 
+                            destination service on which this policy is being 
                             applied.
                           properties:
                             number:
@@ -6842,7 +6842,7 @@ spec:
                               type: integer
                           type: object
                         tls:
-                          description: TLS related settings for connections to
+                          description: TLS related settings for connections to 
                             the upstream service.
                           properties:
                             caCertificates:
@@ -6860,7 +6860,7 @@ spec:
                               type: string
                             credentialName:
                               description: The name of the secret that holds the
-                                TLS certs for the client including the CA
+                                TLS certs for the client including the CA 
                                 certificates.
                               type: string
                             insecureSkipVerify:
@@ -6885,11 +6885,11 @@ spec:
                               description: REQUIRED if mode is `MUTUAL`.
                               type: string
                             sni:
-                              description: SNI string to present to the server
+                              description: SNI string to present to the server 
                                 during TLS handshake.
                               type: string
                             subjectAltNames:
-                              description: A list of alternate names to verify
+                              description: A list of alternate names to verify 
                                 the subject identity in the certificate.
                               items:
                                 type: string
@@ -6912,18 +6912,18 @@ spec:
                         type: string
                     type: object
                   retryBudget:
-                    description: Specifies a limit on concurrent retries in
+                    description: Specifies a limit on concurrent retries in 
                       relation to the number of active requests.
                     properties:
                       minRetryConcurrency:
-                        description: Specifies the minimum retry concurrency
+                        description: Specifies the minimum retry concurrency 
                           allowed for the retry budget.
                         maximum: 4294967295
                         minimum: 0
                         type: integer
                       percent:
-                        description: Specifies the limit on concurrent retries
-                          as a percentage of the sum of active requests and
+                        description: Specifies the limit on concurrent retries 
+                          as a percentage of the sum of active requests and 
                           active pending requests.
                         format: double
                         maximum: 100
@@ -6932,7 +6932,7 @@ spec:
                         type: number
                     type: object
                   tls:
-                    description: TLS related settings for connections to the
+                    description: TLS related settings for connections to the 
                       upstream service.
                     properties:
                       caCertificates:
@@ -6949,7 +6949,7 @@ spec:
                         description: REQUIRED if mode is `MUTUAL`.
                         type: string
                       credentialName:
-                        description: The name of the secret that holds the TLS
+                        description: The name of the secret that holds the TLS 
                           certs for the client including the CA certificates.
                         type: string
                       insecureSkipVerify:
@@ -6973,31 +6973,31 @@ spec:
                         description: REQUIRED if mode is `MUTUAL`.
                         type: string
                       sni:
-                        description: SNI string to present to the server during
+                        description: SNI string to present to the server during 
                           TLS handshake.
                         type: string
                       subjectAltNames:
-                        description: A list of alternate names to verify the
+                        description: A list of alternate names to verify the 
                           subject identity in the certificate.
                         items:
                           type: string
                         type: array
                     type: object
                   tunnel:
-                    description: Configuration of tunneling TCP over other
+                    description: Configuration of tunneling TCP over other 
                       transport or application layers for the host configured in
                       the DestinationRule.
                     properties:
                       protocol:
-                        description: Specifies which protocol to use for
+                        description: Specifies which protocol to use for 
                           tunneling the downstream connection.
                         type: string
                       targetHost:
-                        description: Specifies a host to which the downstream
+                        description: Specifies a host to which the downstream 
                           connection is tunneled.
                         type: string
                       targetPort:
-                        description: Specifies a port to which the downstream
+                        description: Specifies a port to which the downstream 
                           connection is tunneled.
                         maximum: 4294967295
                         minimum: 0
@@ -7008,8 +7008,8 @@ spec:
                     type: object
                 type: object
               workloadSelector:
-                description: Criteria used to select the specific set of
-                  pods/VMs on which this `DestinationRule` configuration should
+                description: Criteria used to select the specific set of 
+                  pods/VMs on which this `DestinationRule` configuration should 
                   be applied.
                 properties:
                   matchLabels:
@@ -7048,18 +7048,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -7098,12 +7098,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -7174,7 +7174,7 @@ spec:
                       - LISTENER_FILTER
                       type: string
                     match:
-                      description: Match on listener/route
+                      description: Match on listener/route 
                         configuration/cluster.
                       oneOf:
                       - not:
@@ -7200,21 +7200,21 @@ spec:
                           description: Match on envoy cluster attributes.
                           properties:
                             name:
-                              description: The exact name of the cluster to
+                              description: The exact name of the cluster to 
                                 match.
                               type: string
                             portNumber:
-                              description: The service port for which this
+                              description: The service port for which this 
                                 cluster was generated.
                               maximum: 4294967295
                               minimum: 0
                               type: integer
                             service:
-                              description: The fully qualified service name for
+                              description: The fully qualified service name for 
                                 this cluster.
                               type: string
                             subset:
-                              description: The subset associated with the
+                              description: The subset associated with the 
                                 service.
                               type: string
                           type: object
@@ -7234,41 +7234,41 @@ spec:
                           description: Match on envoy listener attributes.
                           properties:
                             filterChain:
-                              description: Match a specific filter chain in a
+                              description: Match a specific filter chain in a 
                                 listener.
                               properties:
                                 applicationProtocols:
                                   description: Applies only to sidecars.
                                   type: string
                                 destinationPort:
-                                  description: The destination_port value used
+                                  description: The destination_port value used 
                                     by a filter chain's match condition.
                                   maximum: 4294967295
                                   minimum: 0
                                   type: integer
                                 filter:
-                                  description: The name of a specific filter to
+                                  description: The name of a specific filter to 
                                     apply the patch to.
                                   properties:
                                     name:
                                       description: The filter name to match on.
                                       type: string
                                     subFilter:
-                                      description: The next level filter within
+                                      description: The next level filter within 
                                         this filter to match upon.
                                       properties:
                                         name:
-                                          description: The filter name to match
+                                          description: The filter name to match 
                                             on.
                                           type: string
                                       type: object
                                   type: object
                                 name:
-                                  description: The name assigned to the filter
+                                  description: The name assigned to the filter 
                                     chain.
                                   type: string
                                 sni:
-                                  description: The SNI value used by a filter
+                                  description: The SNI value used by a filter 
                                     chain's match condition.
                                   type: string
                                 transportProtocol:
@@ -7280,41 +7280,41 @@ spec:
                               description: Match a specific listener filter.
                               type: string
                             name:
-                              description: Match a specific listener by its
+                              description: Match a specific listener by its 
                                 name.
                               type: string
                             portName:
                               type: string
                             portNumber:
-                              description: The service port/gateway port to
+                              description: The service port/gateway port to 
                                 which traffic is being sent/received.
                               maximum: 4294967295
                               minimum: 0
                               type: integer
                           type: object
                         proxy:
-                          description: Match on properties associated with a
+                          description: Match on properties associated with a 
                             proxy.
                           properties:
                             metadata:
                               additionalProperties:
                                 type: string
-                              description: Match on the node metadata supplied
+                              description: Match on the node metadata supplied 
                                 by a proxy when connecting to istiod.
                               type: object
                             proxyVersion:
-                              description: A regular expression in golang regex
-                                format (RE2) that can be used to select proxies
+                              description: A regular expression in golang regex 
+                                format (RE2) that can be used to select proxies 
                                 using a specific version of istio proxy.
                               type: string
                           type: object
                         routeConfiguration:
-                          description: Match on envoy HTTP route configuration
+                          description: Match on envoy HTTP route configuration 
                             attributes.
                           properties:
                             gateway:
-                              description: The Istio gateway config's
-                                namespace/name for which this route
+                              description: The Istio gateway config's 
+                                namespace/name for which this route 
                                 configuration was generated.
                               type: string
                             name:
@@ -7324,26 +7324,26 @@ spec:
                               description: Applicable only for GATEWAY context.
                               type: string
                             portNumber:
-                              description: The service port number or gateway
-                                server port number for which this route
+                              description: The service port number or gateway 
+                                server port number for which this route 
                                 configuration was generated.
                               maximum: 4294967295
                               minimum: 0
                               type: integer
                             vhost:
-                              description: Match a specific virtual host in a
-                                route configuration and apply the patch to the
+                              description: Match a specific virtual host in a 
+                                route configuration and apply the patch to the 
                                 virtual host.
                               properties:
                                 domainName:
-                                  description: Match a domain name in a virtual
+                                  description: Match a domain name in a virtual 
                                     host.
                                   type: string
                                 name:
-                                  description: The VirtualHosts objects
-                                    generated by Istio are named as host:port,
-                                    where the host typically corresponds to the
-                                    VirtualService's host field or the hostname
+                                  description: The VirtualHosts objects 
+                                    generated by Istio are named as host:port, 
+                                    where the host typically corresponds to the 
+                                    VirtualService's host field or the hostname 
                                     of a service in the registry.
                                   type: string
                                 route:
@@ -7362,7 +7362,7 @@ spec:
                                       - DIRECT_RESPONSE
                                       type: string
                                     name:
-                                      description: The Route objects generated
+                                      description: The Route objects generated 
                                         by default are named as default.
                                       type: string
                                   type: object
@@ -7371,7 +7371,7 @@ spec:
                         waypoint:
                           properties:
                             filter:
-                              description: The name of a specific filter to
+                              description: The name of a specific filter to 
                                 apply the patch to.
                               properties:
                                 name:
@@ -7398,14 +7398,14 @@ spec:
                               description: Match a specific route.
                               properties:
                                 name:
-                                  description: The Route objects generated by
+                                  description: The Route objects generated by 
                                     default are named as default.
                                   type: string
                               type: object
                           type: object
                       type: object
                       x-kubernetes-validations:
-                      - message: only support waypointMatch when context is
+                      - message: only support waypointMatch when context is 
                           WAYPOINT
                         rule: 'has(self.context) ? ((self.context == "WAYPOINT") ?
                           has(self.waypoint) : !has(self.waypoint)) : !has(self.waypoint)'
@@ -7439,7 +7439,7 @@ spec:
                           - REPLACE
                           type: string
                         value:
-                          description: The JSON config of the object being
+                          description: The JSON config of the object being 
                             patched.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
@@ -7447,7 +7447,7 @@ spec:
                   type: object
                 type: array
               priority:
-                description: Priority defines the order in which patch sets are
+                description: Priority defines the order in which patch sets are 
                   applied within a context.
                 format: int32
                 type: integer
@@ -7458,7 +7458,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -7476,7 +7476,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -7486,7 +7486,7 @@ spec:
                 maxItems: 16
                 type: array
               workloadSelector:
-                description: Criteria used to select the specific set of
+                description: Criteria used to select the specific set of 
                   pods/VMs on which this patch configuration should be applied.
                 properties:
                   labels:
@@ -7522,18 +7522,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -7572,12 +7572,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -7629,8 +7629,8 @@ spec:
               selector:
                 additionalProperties:
                   type: string
-                description: One or more labels that indicate a specific set of
-                  pods/VMs on which this gateway configuration should be
+                description: One or more labels that indicate a specific set of 
+                  pods/VMs on which this gateway configuration should be 
                   applied.
                 type: object
               servers:
@@ -7677,7 +7677,7 @@ spec:
                       - name
                       type: object
                     tls:
-                      description: Set of TLS related options that govern the
+                      description: Set of TLS related options that govern the 
                         server's behavior.
                       properties:
                         caCertCredentialName:
@@ -7685,7 +7685,7 @@ spec:
                             the configmap that holds CA certificates.
                           type: string
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL` or
+                          description: REQUIRED if mode is `MUTUAL` or 
                             `OPTIONAL_MUTUAL`.
                           type: string
                         caCrl:
@@ -7700,12 +7700,12 @@ spec:
                             type: string
                           type: array
                         credentialName:
-                          description: For gateways running on Kubernetes, the
-                            name of the secret that holds the TLS certs
+                          description: For gateways running on Kubernetes, the 
+                            name of the secret that holds the TLS certs 
                             including the CA certificates.
                           type: string
                         credentialNames:
-                          description: Same as CredentialName but for multiple
+                          description: Same as CredentialName but for multiple 
                             certificates.
                           items:
                             type: string
@@ -7713,7 +7713,7 @@ spec:
                           minItems: 1
                           type: array
                         httpsRedirect:
-                          description: If set to true, the load balancer will
+                          description: If set to true, the load balancer will 
                             send a 301 redirect for all http connections, asking
                             the clients to use HTTPS.
                           type: boolean
@@ -7761,27 +7761,27 @@ spec:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
                           type: string
                         subjectAltNames:
-                          description: A list of alternate names to verify the
+                          description: A list of alternate names to verify the 
                             subject identity in the certificate presented by the
                             client.
                           items:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`,
-                            `private_key` or `credential_name` or
-                            `credential_names` or `tls_certificates` should be
+                          description: Only one of `server_certificate`, 
+                            `private_key` or `credential_name` or 
+                            `credential_names` or `tls_certificates` should be 
                             specified.
                           items:
                             properties:
                               caCertificates:
                                 type: string
                               privateKey:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                               serverCertificate:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                             type: object
@@ -7789,29 +7789,29 @@ spec:
                           minItems: 1
                           type: array
                         verifyCertificateHash:
-                          description: An optional list of hex-encoded SHA-256
+                          description: An optional list of hex-encoded SHA-256 
                             hashes of the authorized client certificates.
                           items:
                             type: string
                           type: array
                         verifyCertificateSpki:
-                          description: An optional list of base64-encoded
-                            SHA-256 hashes of the SPKIs of authorized client
+                          description: An optional list of base64-encoded 
+                            SHA-256 hashes of the SPKIs of authorized client 
                             certificates.
                           items:
                             type: string
                           type: array
                       type: object
                       x-kubernetes-validations:
-                      - message: only one of credentialNames or tlsCertificates
+                      - message: only one of credentialNames or tlsCertificates 
                           can be set
                         rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or credentialNames
+                      - message: only one of credentialName or credentialNames 
                           can be set
                         rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or tlsCertificates
+                      - message: only one of credentialName or tlsCertificates 
                           can be set
                         rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
                           ? 1 : 0) <= 1'
@@ -7837,18 +7837,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -7887,12 +7887,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -7916,8 +7916,8 @@ spec:
               selector:
                 additionalProperties:
                   type: string
-                description: One or more labels that indicate a specific set of
-                  pods/VMs on which this gateway configuration should be
+                description: One or more labels that indicate a specific set of 
+                  pods/VMs on which this gateway configuration should be 
                   applied.
                 type: object
               servers:
@@ -7964,7 +7964,7 @@ spec:
                       - name
                       type: object
                     tls:
-                      description: Set of TLS related options that govern the
+                      description: Set of TLS related options that govern the 
                         server's behavior.
                       properties:
                         caCertCredentialName:
@@ -7972,7 +7972,7 @@ spec:
                             the configmap that holds CA certificates.
                           type: string
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL` or
+                          description: REQUIRED if mode is `MUTUAL` or 
                             `OPTIONAL_MUTUAL`.
                           type: string
                         caCrl:
@@ -7987,12 +7987,12 @@ spec:
                             type: string
                           type: array
                         credentialName:
-                          description: For gateways running on Kubernetes, the
-                            name of the secret that holds the TLS certs
+                          description: For gateways running on Kubernetes, the 
+                            name of the secret that holds the TLS certs 
                             including the CA certificates.
                           type: string
                         credentialNames:
-                          description: Same as CredentialName but for multiple
+                          description: Same as CredentialName but for multiple 
                             certificates.
                           items:
                             type: string
@@ -8000,7 +8000,7 @@ spec:
                           minItems: 1
                           type: array
                         httpsRedirect:
-                          description: If set to true, the load balancer will
+                          description: If set to true, the load balancer will 
                             send a 301 redirect for all http connections, asking
                             the clients to use HTTPS.
                           type: boolean
@@ -8048,27 +8048,27 @@ spec:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
                           type: string
                         subjectAltNames:
-                          description: A list of alternate names to verify the
+                          description: A list of alternate names to verify the 
                             subject identity in the certificate presented by the
                             client.
                           items:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`,
-                            `private_key` or `credential_name` or
-                            `credential_names` or `tls_certificates` should be
+                          description: Only one of `server_certificate`, 
+                            `private_key` or `credential_name` or 
+                            `credential_names` or `tls_certificates` should be 
                             specified.
                           items:
                             properties:
                               caCertificates:
                                 type: string
                               privateKey:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                               serverCertificate:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                             type: object
@@ -8076,29 +8076,29 @@ spec:
                           minItems: 1
                           type: array
                         verifyCertificateHash:
-                          description: An optional list of hex-encoded SHA-256
+                          description: An optional list of hex-encoded SHA-256 
                             hashes of the authorized client certificates.
                           items:
                             type: string
                           type: array
                         verifyCertificateSpki:
-                          description: An optional list of base64-encoded
-                            SHA-256 hashes of the SPKIs of authorized client
+                          description: An optional list of base64-encoded 
+                            SHA-256 hashes of the SPKIs of authorized client 
                             certificates.
                           items:
                             type: string
                           type: array
                       type: object
                       x-kubernetes-validations:
-                      - message: only one of credentialNames or tlsCertificates
+                      - message: only one of credentialNames or tlsCertificates 
                           can be set
                         rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or credentialNames
+                      - message: only one of credentialName or credentialNames 
                           can be set
                         rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or tlsCertificates
+                      - message: only one of credentialName or tlsCertificates 
                           can be set
                         rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
                           ? 1 : 0) <= 1'
@@ -8124,18 +8124,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -8174,12 +8174,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -8203,8 +8203,8 @@ spec:
               selector:
                 additionalProperties:
                   type: string
-                description: One or more labels that indicate a specific set of
-                  pods/VMs on which this gateway configuration should be
+                description: One or more labels that indicate a specific set of 
+                  pods/VMs on which this gateway configuration should be 
                   applied.
                 type: object
               servers:
@@ -8251,7 +8251,7 @@ spec:
                       - name
                       type: object
                     tls:
-                      description: Set of TLS related options that govern the
+                      description: Set of TLS related options that govern the 
                         server's behavior.
                       properties:
                         caCertCredentialName:
@@ -8259,7 +8259,7 @@ spec:
                             the configmap that holds CA certificates.
                           type: string
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL` or
+                          description: REQUIRED if mode is `MUTUAL` or 
                             `OPTIONAL_MUTUAL`.
                           type: string
                         caCrl:
@@ -8274,12 +8274,12 @@ spec:
                             type: string
                           type: array
                         credentialName:
-                          description: For gateways running on Kubernetes, the
-                            name of the secret that holds the TLS certs
+                          description: For gateways running on Kubernetes, the 
+                            name of the secret that holds the TLS certs 
                             including the CA certificates.
                           type: string
                         credentialNames:
-                          description: Same as CredentialName but for multiple
+                          description: Same as CredentialName but for multiple 
                             certificates.
                           items:
                             type: string
@@ -8287,7 +8287,7 @@ spec:
                           minItems: 1
                           type: array
                         httpsRedirect:
-                          description: If set to true, the load balancer will
+                          description: If set to true, the load balancer will 
                             send a 301 redirect for all http connections, asking
                             the clients to use HTTPS.
                           type: boolean
@@ -8335,27 +8335,27 @@ spec:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
                           type: string
                         subjectAltNames:
-                          description: A list of alternate names to verify the
+                          description: A list of alternate names to verify the 
                             subject identity in the certificate presented by the
                             client.
                           items:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`,
-                            `private_key` or `credential_name` or
-                            `credential_names` or `tls_certificates` should be
+                          description: Only one of `server_certificate`, 
+                            `private_key` or `credential_name` or 
+                            `credential_names` or `tls_certificates` should be 
                             specified.
                           items:
                             properties:
                               caCertificates:
                                 type: string
                               privateKey:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                               serverCertificate:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                             type: object
@@ -8363,29 +8363,29 @@ spec:
                           minItems: 1
                           type: array
                         verifyCertificateHash:
-                          description: An optional list of hex-encoded SHA-256
+                          description: An optional list of hex-encoded SHA-256 
                             hashes of the authorized client certificates.
                           items:
                             type: string
                           type: array
                         verifyCertificateSpki:
-                          description: An optional list of base64-encoded
-                            SHA-256 hashes of the SPKIs of authorized client
+                          description: An optional list of base64-encoded 
+                            SHA-256 hashes of the SPKIs of authorized client 
                             certificates.
                           items:
                             type: string
                           type: array
                       type: object
                       x-kubernetes-validations:
-                      - message: only one of credentialNames or tlsCertificates
+                      - message: only one of credentialNames or tlsCertificates 
                           can be set
                         rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or credentialNames
+                      - message: only one of credentialName or credentialNames 
                           can be set
                         rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or tlsCertificates
+                      - message: only one of credentialName or tlsCertificates 
                           can be set
                         rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
                           ? 1 : 0) <= 1'
@@ -8411,18 +8411,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -8461,12 +8461,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -8565,7 +8565,7 @@ spec:
                 - message: port must be between 1-65535
                   rule: self.all(key, 0 < int(key) && int(key) <= 65535)
               selector:
-                description: The selector determines the workloads to apply the
+                description: The selector determines the workloads to apply the 
                   PeerAuthentication on.
                 properties:
                   matchLabels:
@@ -8606,18 +8606,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -8656,12 +8656,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -8732,7 +8732,7 @@ spec:
                 - message: port must be between 1-65535
                   rule: self.all(key, 0 < int(key) && int(key) <= 65535)
               selector:
-                description: The selector determines the workloads to apply the
+                description: The selector determines the workloads to apply the 
                   PeerAuthentication on.
                 properties:
                   matchLabels:
@@ -8773,18 +8773,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -8823,12 +8823,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -8931,18 +8931,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -8981,12 +8981,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -9036,12 +9036,12 @@ spec:
               more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
-                description: Define the list of JWTs that can be validated at
+                description: Define the list of JWTs that can be validated at 
                   the selected workloads' proxy.
                 items:
                   properties:
                     audiences:
-                      description: The list of JWT
+                      description: The list of JWT 
                         [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3)
                         that are allowed to access.
                       items:
@@ -9049,18 +9049,18 @@ spec:
                         type: string
                       type: array
                     forwardOriginalToken:
-                      description: If set to true, the original token will be
+                      description: If set to true, the original token will be 
                         kept for the upstream request.
                       type: boolean
                     fromCookies:
-                      description: List of cookie names from which JWT is
+                      description: List of cookie names from which JWT is 
                         expected.
                       items:
                         minLength: 1
                         type: string
                       type: array
                     fromHeaders:
-                      description: List of header locations from which JWT is
+                      description: List of header locations from which JWT is 
                         expected.
                       items:
                         properties:
@@ -9069,7 +9069,7 @@ spec:
                             minLength: 1
                             type: string
                           prefix:
-                            description: The prefix that should be stripped
+                            description: The prefix that should be stripped 
                               before decoding the token.
                             type: string
                         required:
@@ -9077,7 +9077,7 @@ spec:
                         type: object
                       type: array
                     fromParams:
-                      description: List of query parameters from which JWT is
+                      description: List of query parameters from which JWT is 
                         expected.
                       items:
                         minLength: 1
@@ -9088,11 +9088,11 @@ spec:
                       minLength: 1
                       type: string
                     jwks:
-                      description: JSON Web Key Set of public keys to validate
+                      description: JSON Web Key Set of public keys to validate 
                         signature of the JWT.
                       type: string
                     jwks_uri:
-                      description: URL of the provider's public key set to
+                      description: URL of the provider's public key set to 
                         validate signature of the JWT.
                       maxLength: 2048
                       minLength: 1
@@ -9101,7 +9101,7 @@ spec:
                       - message: url must have scheme http:// or https://
                         rule: url(self).getScheme() in ["http", "https"]
                     jwksUri:
-                      description: URL of the provider's public key set to
+                      description: URL of the provider's public key set to 
                         validate signature of the JWT.
                       maxLength: 2048
                       minLength: 1
@@ -9110,13 +9110,13 @@ spec:
                       - message: url must have scheme http:// or https://
                         rule: url(self).getScheme() in ["http", "https"]
                     outputClaimToHeaders:
-                      description: This field specifies a list of operations to
-                        copy the claim to HTTP headers on a successfully
+                      description: This field specifies a list of operations to 
+                        copy the claim to HTTP headers on a successfully 
                         verified token.
                       items:
                         properties:
                           claim:
-                            description: The name of the claim to be copied
+                            description: The name of the claim to be copied 
                               from.
                             minLength: 1
                             type: string
@@ -9131,12 +9131,12 @@ spec:
                         type: object
                       type: array
                     outputPayloadToHeader:
-                      description: This field specifies the header name to
-                        output a successfully verified JWT payload to the
+                      description: This field specifies the header name to 
+                        output a successfully verified JWT payload to the 
                         backend.
                       type: string
                     spaceDelimitedClaims:
-                      description: List of JWT claim names that should be
+                      description: List of JWT claim names that should be 
                         treated as space-delimited strings.
                       items:
                         minLength: 1
@@ -9145,7 +9145,7 @@ spec:
                       type: array
                     timeout:
                       description: The maximum amount of time that the resolver,
-                        determined by the PILOT_JWT_ENABLE_REMOTE_JWKS
+                        determined by the PILOT_JWT_ENABLE_REMOTE_JWKS 
                         environment variable, will spend waiting for the JWKS to
                         be fetched.
                       type: string
@@ -9184,7 +9184,7 @@ spec:
                   group:
                     description: group is the group of the target resource.
                     maxLength: 253
-                    pattern:
+                    pattern: 
                       ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
@@ -9202,7 +9202,7 @@ spec:
                     description: namespace is the namespace of the referent.
                     type: string
                     x-kubernetes-validations:
-                    - message: cross namespace referencing is not currently
+                    - message: cross namespace referencing is not currently 
                         supported
                       rule: self.size() == 0
                 required:
@@ -9216,7 +9216,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -9234,7 +9234,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -9264,18 +9264,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -9314,12 +9314,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -9341,12 +9341,12 @@ spec:
               more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
             properties:
               jwtRules:
-                description: Define the list of JWTs that can be validated at
+                description: Define the list of JWTs that can be validated at 
                   the selected workloads' proxy.
                 items:
                   properties:
                     audiences:
-                      description: The list of JWT
+                      description: The list of JWT 
                         [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3)
                         that are allowed to access.
                       items:
@@ -9354,18 +9354,18 @@ spec:
                         type: string
                       type: array
                     forwardOriginalToken:
-                      description: If set to true, the original token will be
+                      description: If set to true, the original token will be 
                         kept for the upstream request.
                       type: boolean
                     fromCookies:
-                      description: List of cookie names from which JWT is
+                      description: List of cookie names from which JWT is 
                         expected.
                       items:
                         minLength: 1
                         type: string
                       type: array
                     fromHeaders:
-                      description: List of header locations from which JWT is
+                      description: List of header locations from which JWT is 
                         expected.
                       items:
                         properties:
@@ -9374,7 +9374,7 @@ spec:
                             minLength: 1
                             type: string
                           prefix:
-                            description: The prefix that should be stripped
+                            description: The prefix that should be stripped 
                               before decoding the token.
                             type: string
                         required:
@@ -9382,7 +9382,7 @@ spec:
                         type: object
                       type: array
                     fromParams:
-                      description: List of query parameters from which JWT is
+                      description: List of query parameters from which JWT is 
                         expected.
                       items:
                         minLength: 1
@@ -9393,11 +9393,11 @@ spec:
                       minLength: 1
                       type: string
                     jwks:
-                      description: JSON Web Key Set of public keys to validate
+                      description: JSON Web Key Set of public keys to validate 
                         signature of the JWT.
                       type: string
                     jwks_uri:
-                      description: URL of the provider's public key set to
+                      description: URL of the provider's public key set to 
                         validate signature of the JWT.
                       maxLength: 2048
                       minLength: 1
@@ -9406,7 +9406,7 @@ spec:
                       - message: url must have scheme http:// or https://
                         rule: url(self).getScheme() in ["http", "https"]
                     jwksUri:
-                      description: URL of the provider's public key set to
+                      description: URL of the provider's public key set to 
                         validate signature of the JWT.
                       maxLength: 2048
                       minLength: 1
@@ -9415,13 +9415,13 @@ spec:
                       - message: url must have scheme http:// or https://
                         rule: url(self).getScheme() in ["http", "https"]
                     outputClaimToHeaders:
-                      description: This field specifies a list of operations to
-                        copy the claim to HTTP headers on a successfully
+                      description: This field specifies a list of operations to 
+                        copy the claim to HTTP headers on a successfully 
                         verified token.
                       items:
                         properties:
                           claim:
-                            description: The name of the claim to be copied
+                            description: The name of the claim to be copied 
                               from.
                             minLength: 1
                             type: string
@@ -9436,12 +9436,12 @@ spec:
                         type: object
                       type: array
                     outputPayloadToHeader:
-                      description: This field specifies the header name to
-                        output a successfully verified JWT payload to the
+                      description: This field specifies the header name to 
+                        output a successfully verified JWT payload to the 
                         backend.
                       type: string
                     spaceDelimitedClaims:
-                      description: List of JWT claim names that should be
+                      description: List of JWT claim names that should be 
                         treated as space-delimited strings.
                       items:
                         minLength: 1
@@ -9450,7 +9450,7 @@ spec:
                       type: array
                     timeout:
                       description: The maximum amount of time that the resolver,
-                        determined by the PILOT_JWT_ENABLE_REMOTE_JWKS
+                        determined by the PILOT_JWT_ENABLE_REMOTE_JWKS 
                         environment variable, will spend waiting for the JWKS to
                         be fetched.
                       type: string
@@ -9489,7 +9489,7 @@ spec:
                   group:
                     description: group is the group of the target resource.
                     maxLength: 253
-                    pattern:
+                    pattern: 
                       ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
@@ -9507,7 +9507,7 @@ spec:
                     description: namespace is the namespace of the referent.
                     type: string
                     x-kubernetes-validations:
-                    - message: cross namespace referencing is not currently
+                    - message: cross namespace referencing is not currently 
                         supported
                       rule: self.size() == 0
                 required:
@@ -9521,7 +9521,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -9539,7 +9539,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -9569,18 +9569,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -9619,12 +9619,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -9670,7 +9670,7 @@ spec:
       jsonPath: .spec.hosts
       name: Hosts
       type: string
-    - description: Whether the service is external to the mesh or part of the
+    - description: Whether the service is external to the mesh or part of the 
         mesh (MESH_EXTERNAL or MESH_INTERNAL)
       jsonPath: .spec.location
       name: Location
@@ -9696,7 +9696,7 @@ spec:
               at: https://istio.io/docs/reference/config/networking/service-entry.html'
             properties:
               addresses:
-                description: The virtual IP addresses associated with the
+                description: The virtual IP addresses associated with the 
                   service.
                 items:
                   maxLength: 64
@@ -9708,7 +9708,7 @@ spec:
                 items:
                   properties:
                     address:
-                      description: Address associated with the network endpoint
+                      description: Address associated with the network endpoint 
                         without the port.
                       maxLength: 256
                       type: string
@@ -9722,7 +9722,7 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: One or more labels associated with the
+                      description: One or more labels associated with the 
                         endpoint.
                       maxProperties: 256
                       type: object
@@ -9731,7 +9731,7 @@ spec:
                       maxLength: 2048
                       type: string
                     network:
-                      description: Network enables Istio to group endpoints
+                      description: Network enables Istio to group endpoints 
                         resident in the same L3 domain/network.
                       maxLength: 2048
                       type: string
@@ -9748,10 +9748,10 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: port name must be valid
-                        rule: self.all(key, size(key) < 63 &&
+                        rule: self.all(key, size(key) < 63 && 
                           key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
                     serviceAccount:
-                      description: The service account associated with the
+                      description: The service account associated with the 
                         workload if a sidecar is present in the workload.
                       maxLength: 253
                       type: string
@@ -9771,7 +9771,7 @@ spec:
                 maxItems: 4096
                 type: array
               exportTo:
-                description: A list of namespaces to which this service is
+                description: A list of namespaces to which this service is 
                   exported.
                 items:
                   type: string
@@ -9816,7 +9816,7 @@ spec:
                       maxLength: 256
                       type: string
                     targetPort:
-                      description: The port number on the endpoint where the
+                      description: The port number on the endpoint where the 
                         traffic will be received.
                       maximum: 4294967295
                       minimum: 0
@@ -9835,7 +9835,7 @@ spec:
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
                 - message: port number cannot be duplicated
-                  rule: self.all(l1, self.exists_one(l2, l1.number ==
+                  rule: self.all(l1, self.exists_one(l2, l1.number == 
                     l2.number))
               resolution:
                 description: |-
@@ -9851,7 +9851,7 @@ spec:
                 type: string
               subjectAltNames:
                 description: If specified, the proxy will verify that the server
-                  certificate's subject alternate name matches one of the
+                  certificate's subject alternate name matches one of the 
                   specified values.
                 items:
                   type: string
@@ -9878,7 +9878,7 @@ spec:
             - message: only one of WorkloadSelector or Endpoints can be set
               rule: '(has(self.workloadSelector) ? 1 : 0) + (has(self.endpoints) ?
                 1 : 0) <= 1'
-            - message: CIDR addresses are allowed only for NONE/STATIC
+            - message: CIDR addresses are allowed only for NONE/STATIC 
                 resolution types
               rule: '!((has(self.addresses) ? self.addresses : []).exists(k, k.contains("/"))
                 && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
@@ -9905,18 +9905,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -9955,12 +9955,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -9980,7 +9980,7 @@ spec:
       jsonPath: .spec.hosts
       name: Hosts
       type: string
-    - description: Whether the service is external to the mesh or part of the
+    - description: Whether the service is external to the mesh or part of the 
         mesh (MESH_EXTERNAL or MESH_INTERNAL)
       jsonPath: .spec.location
       name: Location
@@ -10006,7 +10006,7 @@ spec:
               at: https://istio.io/docs/reference/config/networking/service-entry.html'
             properties:
               addresses:
-                description: The virtual IP addresses associated with the
+                description: The virtual IP addresses associated with the 
                   service.
                 items:
                   maxLength: 64
@@ -10018,7 +10018,7 @@ spec:
                 items:
                   properties:
                     address:
-                      description: Address associated with the network endpoint
+                      description: Address associated with the network endpoint 
                         without the port.
                       maxLength: 256
                       type: string
@@ -10032,7 +10032,7 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: One or more labels associated with the
+                      description: One or more labels associated with the 
                         endpoint.
                       maxProperties: 256
                       type: object
@@ -10041,7 +10041,7 @@ spec:
                       maxLength: 2048
                       type: string
                     network:
-                      description: Network enables Istio to group endpoints
+                      description: Network enables Istio to group endpoints 
                         resident in the same L3 domain/network.
                       maxLength: 2048
                       type: string
@@ -10058,10 +10058,10 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: port name must be valid
-                        rule: self.all(key, size(key) < 63 &&
+                        rule: self.all(key, size(key) < 63 && 
                           key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
                     serviceAccount:
-                      description: The service account associated with the
+                      description: The service account associated with the 
                         workload if a sidecar is present in the workload.
                       maxLength: 253
                       type: string
@@ -10081,7 +10081,7 @@ spec:
                 maxItems: 4096
                 type: array
               exportTo:
-                description: A list of namespaces to which this service is
+                description: A list of namespaces to which this service is 
                   exported.
                 items:
                   type: string
@@ -10126,7 +10126,7 @@ spec:
                       maxLength: 256
                       type: string
                     targetPort:
-                      description: The port number on the endpoint where the
+                      description: The port number on the endpoint where the 
                         traffic will be received.
                       maximum: 4294967295
                       minimum: 0
@@ -10145,7 +10145,7 @@ spec:
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
                 - message: port number cannot be duplicated
-                  rule: self.all(l1, self.exists_one(l2, l1.number ==
+                  rule: self.all(l1, self.exists_one(l2, l1.number == 
                     l2.number))
               resolution:
                 description: |-
@@ -10161,7 +10161,7 @@ spec:
                 type: string
               subjectAltNames:
                 description: If specified, the proxy will verify that the server
-                  certificate's subject alternate name matches one of the
+                  certificate's subject alternate name matches one of the 
                   specified values.
                 items:
                   type: string
@@ -10188,7 +10188,7 @@ spec:
             - message: only one of WorkloadSelector or Endpoints can be set
               rule: '(has(self.workloadSelector) ? 1 : 0) + (has(self.endpoints) ?
                 1 : 0) <= 1'
-            - message: CIDR addresses are allowed only for NONE/STATIC
+            - message: CIDR addresses are allowed only for NONE/STATIC 
                 resolution types
               rule: '!((has(self.addresses) ? self.addresses : []).exists(k, k.contains("/"))
                 && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
@@ -10215,18 +10215,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -10265,12 +10265,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -10290,7 +10290,7 @@ spec:
       jsonPath: .spec.hosts
       name: Hosts
       type: string
-    - description: Whether the service is external to the mesh or part of the
+    - description: Whether the service is external to the mesh or part of the 
         mesh (MESH_EXTERNAL or MESH_INTERNAL)
       jsonPath: .spec.location
       name: Location
@@ -10316,7 +10316,7 @@ spec:
               at: https://istio.io/docs/reference/config/networking/service-entry.html'
             properties:
               addresses:
-                description: The virtual IP addresses associated with the
+                description: The virtual IP addresses associated with the 
                   service.
                 items:
                   maxLength: 64
@@ -10328,7 +10328,7 @@ spec:
                 items:
                   properties:
                     address:
-                      description: Address associated with the network endpoint
+                      description: Address associated with the network endpoint 
                         without the port.
                       maxLength: 256
                       type: string
@@ -10342,7 +10342,7 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: One or more labels associated with the
+                      description: One or more labels associated with the 
                         endpoint.
                       maxProperties: 256
                       type: object
@@ -10351,7 +10351,7 @@ spec:
                       maxLength: 2048
                       type: string
                     network:
-                      description: Network enables Istio to group endpoints
+                      description: Network enables Istio to group endpoints 
                         resident in the same L3 domain/network.
                       maxLength: 2048
                       type: string
@@ -10368,10 +10368,10 @@ spec:
                       type: object
                       x-kubernetes-validations:
                       - message: port name must be valid
-                        rule: self.all(key, size(key) < 63 &&
+                        rule: self.all(key, size(key) < 63 && 
                           key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
                     serviceAccount:
-                      description: The service account associated with the
+                      description: The service account associated with the 
                         workload if a sidecar is present in the workload.
                       maxLength: 253
                       type: string
@@ -10391,7 +10391,7 @@ spec:
                 maxItems: 4096
                 type: array
               exportTo:
-                description: A list of namespaces to which this service is
+                description: A list of namespaces to which this service is 
                   exported.
                 items:
                   type: string
@@ -10436,7 +10436,7 @@ spec:
                       maxLength: 256
                       type: string
                     targetPort:
-                      description: The port number on the endpoint where the
+                      description: The port number on the endpoint where the 
                         traffic will be received.
                       maximum: 4294967295
                       minimum: 0
@@ -10455,7 +10455,7 @@ spec:
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
                 - message: port number cannot be duplicated
-                  rule: self.all(l1, self.exists_one(l2, l1.number ==
+                  rule: self.all(l1, self.exists_one(l2, l1.number == 
                     l2.number))
               resolution:
                 description: |-
@@ -10471,7 +10471,7 @@ spec:
                 type: string
               subjectAltNames:
                 description: If specified, the proxy will verify that the server
-                  certificate's subject alternate name matches one of the
+                  certificate's subject alternate name matches one of the 
                   specified values.
                 items:
                   type: string
@@ -10498,7 +10498,7 @@ spec:
             - message: only one of WorkloadSelector or Endpoints can be set
               rule: '(has(self.workloadSelector) ? 1 : 0) + (has(self.endpoints) ?
                 1 : 0) <= 1'
-            - message: CIDR addresses are allowed only for NONE/STATIC
+            - message: CIDR addresses are allowed only for NONE/STATIC 
                 resolution types
               rule: '!((has(self.addresses) ? self.addresses : []).exists(k, k.contains("/"))
                 && !((has(self.resolution) ? self.resolution : "NONE") in ["STATIC",
@@ -10525,18 +10525,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -10575,12 +10575,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -10630,13 +10630,13 @@ spec:
               See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
             properties:
               egress:
-                description: Egress specifies the configuration of the sidecar
-                  for processing outbound traffic from the attached workload
+                description: Egress specifies the configuration of the sidecar 
+                  for processing outbound traffic from the attached workload 
                   instance to other services in the mesh.
                 items:
                   properties:
                     bind:
-                      description: The IP(IPv4 or IPv6) or the Unix domain
+                      description: The IP(IPv4 or IPv6) or the Unix domain 
                         socket to which the listener should be bound to.
                       type: string
                     captureMode:
@@ -10650,7 +10650,7 @@ spec:
                       - NONE
                       type: string
                     hosts:
-                      description: One or more service hosts exposed by the
+                      description: One or more service hosts exposed by the 
                         listener in `namespace/dnsName` format.
                       items:
                         type: string
@@ -10679,7 +10679,7 @@ spec:
                   type: object
                 type: array
               inboundConnectionPool:
-                description: Settings controlling the volume of connections
+                description: Settings controlling the volume of connections 
                   Envoy will accept from the network.
                 properties:
                   http:
@@ -10696,45 +10696,45 @@ spec:
                         - UPGRADE
                         type: string
                       http1MaxPendingRequests:
-                        description: Maximum number of requests that will be
-                          queued while waiting for a ready connection pool
+                        description: Maximum number of requests that will be 
+                          queued while waiting for a ready connection pool 
                           connection.
                         format: int32
                         type: integer
                       http2MaxRequests:
-                        description: Maximum number of active requests to a
+                        description: Maximum number of active requests to a 
                           destination.
                         format: int32
                         type: integer
                       idleTimeout:
-                        description: The idle timeout for upstream connection
+                        description: The idle timeout for upstream connection 
                           pool connections.
                         type: string
                         x-kubernetes-validations:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       maxConcurrentStreams:
-                        description: The maximum number of concurrent streams
+                        description: The maximum number of concurrent streams 
                           allowed for a peer on one HTTP/2 connection.
                         format: int32
                         type: integer
                       maxRequestsPerConnection:
-                        description: Maximum number of requests per connection
+                        description: Maximum number of requests per connection 
                           to a backend.
                         format: int32
                         type: integer
                       maxRetries:
-                        description: Maximum number of retries that can be
+                        description: Maximum number of retries that can be 
                           outstanding to all hosts in a cluster at a given time.
                         format: int32
                         type: integer
                       useClientProtocol:
-                        description: If set to true, client protocol will be
+                        description: If set to true, client protocol will be 
                           preserved while initiating connection to backend.
                         type: boolean
                     type: object
                   tcp:
-                    description: Settings common to both HTTP and TCP upstream
+                    description: Settings common to both HTTP and TCP upstream 
                       connections.
                     properties:
                       connectTimeout:
@@ -10758,19 +10758,19 @@ spec:
                         format: int32
                         type: integer
                       tcpKeepalive:
-                        description: If set then set SO_KEEPALIVE on the socket
+                        description: If set then set SO_KEEPALIVE on the socket 
                           to enable TCP Keepalives.
                         properties:
                           interval:
-                            description: The time duration between keep-alive
+                            description: The time duration between keep-alive 
                               probes.
                             type: string
                             x-kubernetes-validations:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           probes:
-                            description: Maximum number of keepalive probes to
-                              send without response before deciding the
+                            description: Maximum number of keepalive probes to 
+                              send without response before deciding the 
                               connection is dead.
                             maximum: 4294967295
                             minimum: 0
@@ -10786,13 +10786,13 @@ spec:
                     type: object
                 type: object
               ingress:
-                description: Ingress specifies the configuration of the sidecar
-                  for processing inbound traffic to the attached workload
+                description: Ingress specifies the configuration of the sidecar 
+                  for processing inbound traffic to the attached workload 
                   instance.
                 items:
                   properties:
                     bind:
-                      description: The IP(IPv4 or IPv6) to which the listener
+                      description: The IP(IPv4 or IPv6) to which the listener 
                         should be bound.
                       type: string
                     captureMode:
@@ -10806,7 +10806,7 @@ spec:
                       - NONE
                       type: string
                     connectionPool:
-                      description: Settings controlling the volume of
+                      description: Settings controlling the volume of 
                         connections Envoy will accept from the network.
                       properties:
                         http:
@@ -10823,32 +10823,32 @@ spec:
                               - UPGRADE
                               type: string
                             http1MaxPendingRequests:
-                              description: Maximum number of requests that will
-                                be queued while waiting for a ready connection
+                              description: Maximum number of requests that will 
+                                be queued while waiting for a ready connection 
                                 pool connection.
                               format: int32
                               type: integer
                             http2MaxRequests:
-                              description: Maximum number of active requests to
+                              description: Maximum number of active requests to 
                                 a destination.
                               format: int32
                               type: integer
                             idleTimeout:
-                              description: The idle timeout for upstream
+                              description: The idle timeout for upstream 
                                 connection pool connections.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxConcurrentStreams:
-                              description: The maximum number of concurrent
-                                streams allowed for a peer on one HTTP/2
+                              description: The maximum number of concurrent 
+                                streams allowed for a peer on one HTTP/2 
                                 connection.
                               format: int32
                               type: integer
                             maxRequestsPerConnection:
-                              description: Maximum number of requests per
+                              description: Maximum number of requests per 
                                 connection to a backend.
                               format: int32
                               type: integer
@@ -10859,20 +10859,20 @@ spec:
                               format: int32
                               type: integer
                             useClientProtocol:
-                              description: If set to true, client protocol will
-                                be preserved while initiating connection to
+                              description: If set to true, client protocol will 
+                                be preserved while initiating connection to 
                                 backend.
                               type: boolean
                           type: object
                         tcp:
-                          description: Settings common to both HTTP and TCP
+                          description: Settings common to both HTTP and TCP 
                             upstream connections.
                           properties:
                             connectTimeout:
                               description: TCP connection timeout.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             idleTimeout:
@@ -10882,47 +10882,47 @@ spec:
                               description: The maximum duration of a connection.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxConnections:
-                              description: Maximum number of HTTP1 /TCP
+                              description: Maximum number of HTTP1 /TCP 
                                 connections to a destination host.
                               format: int32
                               type: integer
                             tcpKeepalive:
-                              description: If set then set SO_KEEPALIVE on the
+                              description: If set then set SO_KEEPALIVE on the 
                                 socket to enable TCP Keepalives.
                               properties:
                                 interval:
-                                  description: The time duration between
+                                  description: The time duration between 
                                     keep-alive probes.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 probes:
-                                  description: Maximum number of keepalive
-                                    probes to send without response before
+                                  description: Maximum number of keepalive 
+                                    probes to send without response before 
                                     deciding the connection is dead.
                                   maximum: 4294967295
                                   minimum: 0
                                   type: integer
                                 time:
-                                  description: The time duration a connection
-                                    needs to be idle before keep-alive probes
+                                  description: The time duration a connection 
+                                    needs to be idle before keep-alive probes 
                                     start being sent.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                               type: object
                           type: object
                       type: object
                     defaultEndpoint:
-                      description: The IP endpoint or Unix domain socket to
+                      description: The IP endpoint or Unix domain socket to 
                         which traffic should be forwarded to.
                       type: string
                     port:
@@ -10945,8 +10945,8 @@ spec:
                           type: integer
                       type: object
                     tls:
-                      description: Set of TLS related options that will enable
-                        TLS termination on the sidecar for requests originating
+                      description: Set of TLS related options that will enable 
+                        TLS termination on the sidecar for requests originating 
                         from outside the mesh.
                       properties:
                         caCertCredentialName:
@@ -10954,7 +10954,7 @@ spec:
                             the configmap that holds CA certificates.
                           type: string
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL` or
+                          description: REQUIRED if mode is `MUTUAL` or 
                             `OPTIONAL_MUTUAL`.
                           type: string
                         caCrl:
@@ -10969,12 +10969,12 @@ spec:
                             type: string
                           type: array
                         credentialName:
-                          description: For gateways running on Kubernetes, the
-                            name of the secret that holds the TLS certs
+                          description: For gateways running on Kubernetes, the 
+                            name of the secret that holds the TLS certs 
                             including the CA certificates.
                           type: string
                         credentialNames:
-                          description: Same as CredentialName but for multiple
+                          description: Same as CredentialName but for multiple 
                             certificates.
                           items:
                             type: string
@@ -10982,7 +10982,7 @@ spec:
                           minItems: 1
                           type: array
                         httpsRedirect:
-                          description: If set to true, the load balancer will
+                          description: If set to true, the load balancer will 
                             send a 301 redirect for all http connections, asking
                             the clients to use HTTPS.
                           type: boolean
@@ -11030,27 +11030,27 @@ spec:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
                           type: string
                         subjectAltNames:
-                          description: A list of alternate names to verify the
+                          description: A list of alternate names to verify the 
                             subject identity in the certificate presented by the
                             client.
                           items:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`,
-                            `private_key` or `credential_name` or
-                            `credential_names` or `tls_certificates` should be
+                          description: Only one of `server_certificate`, 
+                            `private_key` or `credential_name` or 
+                            `credential_names` or `tls_certificates` should be 
                             specified.
                           items:
                             properties:
                               caCertificates:
                                 type: string
                               privateKey:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                               serverCertificate:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                             type: object
@@ -11058,29 +11058,29 @@ spec:
                           minItems: 1
                           type: array
                         verifyCertificateHash:
-                          description: An optional list of hex-encoded SHA-256
+                          description: An optional list of hex-encoded SHA-256 
                             hashes of the authorized client certificates.
                           items:
                             type: string
                           type: array
                         verifyCertificateSpki:
-                          description: An optional list of base64-encoded
-                            SHA-256 hashes of the SPKIs of authorized client
+                          description: An optional list of base64-encoded 
+                            SHA-256 hashes of the SPKIs of authorized client 
                             certificates.
                           items:
                             type: string
                           type: array
                       type: object
                       x-kubernetes-validations:
-                      - message: only one of credentialNames or tlsCertificates
+                      - message: only one of credentialNames or tlsCertificates 
                           can be set
                         rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or credentialNames
+                      - message: only one of credentialName or credentialNames 
                           can be set
                         rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or tlsCertificates
+                      - message: only one of credentialName or tlsCertificates 
                           can be set
                         rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
                           ? 1 : 0) <= 1'
@@ -11089,17 +11089,17 @@ spec:
                   type: object
                 type: array
               outboundTrafficPolicy:
-                description: Set the default behavior of the sidecar for
+                description: Set the default behavior of the sidecar for 
                   handling outbound traffic from the application.
                 properties:
                   egressProxy:
                     properties:
                       host:
-                        description: The name of a service from the service
+                        description: The name of a service from the service 
                           registry.
                         type: string
                       port:
-                        description: Specifies the port on the host that is
+                        description: Specifies the port on the host that is 
                           being addressed.
                         properties:
                           number:
@@ -11124,8 +11124,8 @@ spec:
                     type: string
                 type: object
               workloadSelector:
-                description: Criteria used to select the specific set of
-                  pods/VMs on which this `Sidecar` configuration should be
+                description: Criteria used to select the specific set of 
+                  pods/VMs on which this `Sidecar` configuration should be 
                   applied.
                 properties:
                   labels:
@@ -11157,18 +11157,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -11207,12 +11207,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -11234,13 +11234,13 @@ spec:
               See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
             properties:
               egress:
-                description: Egress specifies the configuration of the sidecar
-                  for processing outbound traffic from the attached workload
+                description: Egress specifies the configuration of the sidecar 
+                  for processing outbound traffic from the attached workload 
                   instance to other services in the mesh.
                 items:
                   properties:
                     bind:
-                      description: The IP(IPv4 or IPv6) or the Unix domain
+                      description: The IP(IPv4 or IPv6) or the Unix domain 
                         socket to which the listener should be bound to.
                       type: string
                     captureMode:
@@ -11254,7 +11254,7 @@ spec:
                       - NONE
                       type: string
                     hosts:
-                      description: One or more service hosts exposed by the
+                      description: One or more service hosts exposed by the 
                         listener in `namespace/dnsName` format.
                       items:
                         type: string
@@ -11283,7 +11283,7 @@ spec:
                   type: object
                 type: array
               inboundConnectionPool:
-                description: Settings controlling the volume of connections
+                description: Settings controlling the volume of connections 
                   Envoy will accept from the network.
                 properties:
                   http:
@@ -11300,45 +11300,45 @@ spec:
                         - UPGRADE
                         type: string
                       http1MaxPendingRequests:
-                        description: Maximum number of requests that will be
-                          queued while waiting for a ready connection pool
+                        description: Maximum number of requests that will be 
+                          queued while waiting for a ready connection pool 
                           connection.
                         format: int32
                         type: integer
                       http2MaxRequests:
-                        description: Maximum number of active requests to a
+                        description: Maximum number of active requests to a 
                           destination.
                         format: int32
                         type: integer
                       idleTimeout:
-                        description: The idle timeout for upstream connection
+                        description: The idle timeout for upstream connection 
                           pool connections.
                         type: string
                         x-kubernetes-validations:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       maxConcurrentStreams:
-                        description: The maximum number of concurrent streams
+                        description: The maximum number of concurrent streams 
                           allowed for a peer on one HTTP/2 connection.
                         format: int32
                         type: integer
                       maxRequestsPerConnection:
-                        description: Maximum number of requests per connection
+                        description: Maximum number of requests per connection 
                           to a backend.
                         format: int32
                         type: integer
                       maxRetries:
-                        description: Maximum number of retries that can be
+                        description: Maximum number of retries that can be 
                           outstanding to all hosts in a cluster at a given time.
                         format: int32
                         type: integer
                       useClientProtocol:
-                        description: If set to true, client protocol will be
+                        description: If set to true, client protocol will be 
                           preserved while initiating connection to backend.
                         type: boolean
                     type: object
                   tcp:
-                    description: Settings common to both HTTP and TCP upstream
+                    description: Settings common to both HTTP and TCP upstream 
                       connections.
                     properties:
                       connectTimeout:
@@ -11362,19 +11362,19 @@ spec:
                         format: int32
                         type: integer
                       tcpKeepalive:
-                        description: If set then set SO_KEEPALIVE on the socket
+                        description: If set then set SO_KEEPALIVE on the socket 
                           to enable TCP Keepalives.
                         properties:
                           interval:
-                            description: The time duration between keep-alive
+                            description: The time duration between keep-alive 
                               probes.
                             type: string
                             x-kubernetes-validations:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           probes:
-                            description: Maximum number of keepalive probes to
-                              send without response before deciding the
+                            description: Maximum number of keepalive probes to 
+                              send without response before deciding the 
                               connection is dead.
                             maximum: 4294967295
                             minimum: 0
@@ -11390,13 +11390,13 @@ spec:
                     type: object
                 type: object
               ingress:
-                description: Ingress specifies the configuration of the sidecar
-                  for processing inbound traffic to the attached workload
+                description: Ingress specifies the configuration of the sidecar 
+                  for processing inbound traffic to the attached workload 
                   instance.
                 items:
                   properties:
                     bind:
-                      description: The IP(IPv4 or IPv6) to which the listener
+                      description: The IP(IPv4 or IPv6) to which the listener 
                         should be bound.
                       type: string
                     captureMode:
@@ -11410,7 +11410,7 @@ spec:
                       - NONE
                       type: string
                     connectionPool:
-                      description: Settings controlling the volume of
+                      description: Settings controlling the volume of 
                         connections Envoy will accept from the network.
                       properties:
                         http:
@@ -11427,32 +11427,32 @@ spec:
                               - UPGRADE
                               type: string
                             http1MaxPendingRequests:
-                              description: Maximum number of requests that will
-                                be queued while waiting for a ready connection
+                              description: Maximum number of requests that will 
+                                be queued while waiting for a ready connection 
                                 pool connection.
                               format: int32
                               type: integer
                             http2MaxRequests:
-                              description: Maximum number of active requests to
+                              description: Maximum number of active requests to 
                                 a destination.
                               format: int32
                               type: integer
                             idleTimeout:
-                              description: The idle timeout for upstream
+                              description: The idle timeout for upstream 
                                 connection pool connections.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxConcurrentStreams:
-                              description: The maximum number of concurrent
-                                streams allowed for a peer on one HTTP/2
+                              description: The maximum number of concurrent 
+                                streams allowed for a peer on one HTTP/2 
                                 connection.
                               format: int32
                               type: integer
                             maxRequestsPerConnection:
-                              description: Maximum number of requests per
+                              description: Maximum number of requests per 
                                 connection to a backend.
                               format: int32
                               type: integer
@@ -11463,20 +11463,20 @@ spec:
                               format: int32
                               type: integer
                             useClientProtocol:
-                              description: If set to true, client protocol will
-                                be preserved while initiating connection to
+                              description: If set to true, client protocol will 
+                                be preserved while initiating connection to 
                                 backend.
                               type: boolean
                           type: object
                         tcp:
-                          description: Settings common to both HTTP and TCP
+                          description: Settings common to both HTTP and TCP 
                             upstream connections.
                           properties:
                             connectTimeout:
                               description: TCP connection timeout.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             idleTimeout:
@@ -11486,47 +11486,47 @@ spec:
                               description: The maximum duration of a connection.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxConnections:
-                              description: Maximum number of HTTP1 /TCP
+                              description: Maximum number of HTTP1 /TCP 
                                 connections to a destination host.
                               format: int32
                               type: integer
                             tcpKeepalive:
-                              description: If set then set SO_KEEPALIVE on the
+                              description: If set then set SO_KEEPALIVE on the 
                                 socket to enable TCP Keepalives.
                               properties:
                                 interval:
-                                  description: The time duration between
+                                  description: The time duration between 
                                     keep-alive probes.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 probes:
-                                  description: Maximum number of keepalive
-                                    probes to send without response before
+                                  description: Maximum number of keepalive 
+                                    probes to send without response before 
                                     deciding the connection is dead.
                                   maximum: 4294967295
                                   minimum: 0
                                   type: integer
                                 time:
-                                  description: The time duration a connection
-                                    needs to be idle before keep-alive probes
+                                  description: The time duration a connection 
+                                    needs to be idle before keep-alive probes 
                                     start being sent.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                               type: object
                           type: object
                       type: object
                     defaultEndpoint:
-                      description: The IP endpoint or Unix domain socket to
+                      description: The IP endpoint or Unix domain socket to 
                         which traffic should be forwarded to.
                       type: string
                     port:
@@ -11549,8 +11549,8 @@ spec:
                           type: integer
                       type: object
                     tls:
-                      description: Set of TLS related options that will enable
-                        TLS termination on the sidecar for requests originating
+                      description: Set of TLS related options that will enable 
+                        TLS termination on the sidecar for requests originating 
                         from outside the mesh.
                       properties:
                         caCertCredentialName:
@@ -11558,7 +11558,7 @@ spec:
                             the configmap that holds CA certificates.
                           type: string
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL` or
+                          description: REQUIRED if mode is `MUTUAL` or 
                             `OPTIONAL_MUTUAL`.
                           type: string
                         caCrl:
@@ -11573,12 +11573,12 @@ spec:
                             type: string
                           type: array
                         credentialName:
-                          description: For gateways running on Kubernetes, the
-                            name of the secret that holds the TLS certs
+                          description: For gateways running on Kubernetes, the 
+                            name of the secret that holds the TLS certs 
                             including the CA certificates.
                           type: string
                         credentialNames:
-                          description: Same as CredentialName but for multiple
+                          description: Same as CredentialName but for multiple 
                             certificates.
                           items:
                             type: string
@@ -11586,7 +11586,7 @@ spec:
                           minItems: 1
                           type: array
                         httpsRedirect:
-                          description: If set to true, the load balancer will
+                          description: If set to true, the load balancer will 
                             send a 301 redirect for all http connections, asking
                             the clients to use HTTPS.
                           type: boolean
@@ -11634,27 +11634,27 @@ spec:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
                           type: string
                         subjectAltNames:
-                          description: A list of alternate names to verify the
+                          description: A list of alternate names to verify the 
                             subject identity in the certificate presented by the
                             client.
                           items:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`,
-                            `private_key` or `credential_name` or
-                            `credential_names` or `tls_certificates` should be
+                          description: Only one of `server_certificate`, 
+                            `private_key` or `credential_name` or 
+                            `credential_names` or `tls_certificates` should be 
                             specified.
                           items:
                             properties:
                               caCertificates:
                                 type: string
                               privateKey:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                               serverCertificate:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                             type: object
@@ -11662,29 +11662,29 @@ spec:
                           minItems: 1
                           type: array
                         verifyCertificateHash:
-                          description: An optional list of hex-encoded SHA-256
+                          description: An optional list of hex-encoded SHA-256 
                             hashes of the authorized client certificates.
                           items:
                             type: string
                           type: array
                         verifyCertificateSpki:
-                          description: An optional list of base64-encoded
-                            SHA-256 hashes of the SPKIs of authorized client
+                          description: An optional list of base64-encoded 
+                            SHA-256 hashes of the SPKIs of authorized client 
                             certificates.
                           items:
                             type: string
                           type: array
                       type: object
                       x-kubernetes-validations:
-                      - message: only one of credentialNames or tlsCertificates
+                      - message: only one of credentialNames or tlsCertificates 
                           can be set
                         rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or credentialNames
+                      - message: only one of credentialName or credentialNames 
                           can be set
                         rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or tlsCertificates
+                      - message: only one of credentialName or tlsCertificates 
                           can be set
                         rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
                           ? 1 : 0) <= 1'
@@ -11693,17 +11693,17 @@ spec:
                   type: object
                 type: array
               outboundTrafficPolicy:
-                description: Set the default behavior of the sidecar for
+                description: Set the default behavior of the sidecar for 
                   handling outbound traffic from the application.
                 properties:
                   egressProxy:
                     properties:
                       host:
-                        description: The name of a service from the service
+                        description: The name of a service from the service 
                           registry.
                         type: string
                       port:
-                        description: Specifies the port on the host that is
+                        description: Specifies the port on the host that is 
                           being addressed.
                         properties:
                           number:
@@ -11728,8 +11728,8 @@ spec:
                     type: string
                 type: object
               workloadSelector:
-                description: Criteria used to select the specific set of
-                  pods/VMs on which this `Sidecar` configuration should be
+                description: Criteria used to select the specific set of 
+                  pods/VMs on which this `Sidecar` configuration should be 
                   applied.
                 properties:
                   labels:
@@ -11761,18 +11761,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -11811,12 +11811,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -11838,13 +11838,13 @@ spec:
               See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
             properties:
               egress:
-                description: Egress specifies the configuration of the sidecar
-                  for processing outbound traffic from the attached workload
+                description: Egress specifies the configuration of the sidecar 
+                  for processing outbound traffic from the attached workload 
                   instance to other services in the mesh.
                 items:
                   properties:
                     bind:
-                      description: The IP(IPv4 or IPv6) or the Unix domain
+                      description: The IP(IPv4 or IPv6) or the Unix domain 
                         socket to which the listener should be bound to.
                       type: string
                     captureMode:
@@ -11858,7 +11858,7 @@ spec:
                       - NONE
                       type: string
                     hosts:
-                      description: One or more service hosts exposed by the
+                      description: One or more service hosts exposed by the 
                         listener in `namespace/dnsName` format.
                       items:
                         type: string
@@ -11887,7 +11887,7 @@ spec:
                   type: object
                 type: array
               inboundConnectionPool:
-                description: Settings controlling the volume of connections
+                description: Settings controlling the volume of connections 
                   Envoy will accept from the network.
                 properties:
                   http:
@@ -11904,45 +11904,45 @@ spec:
                         - UPGRADE
                         type: string
                       http1MaxPendingRequests:
-                        description: Maximum number of requests that will be
-                          queued while waiting for a ready connection pool
+                        description: Maximum number of requests that will be 
+                          queued while waiting for a ready connection pool 
                           connection.
                         format: int32
                         type: integer
                       http2MaxRequests:
-                        description: Maximum number of active requests to a
+                        description: Maximum number of active requests to a 
                           destination.
                         format: int32
                         type: integer
                       idleTimeout:
-                        description: The idle timeout for upstream connection
+                        description: The idle timeout for upstream connection 
                           pool connections.
                         type: string
                         x-kubernetes-validations:
                         - message: must be a valid duration greater than 1ms
                           rule: duration(self) >= duration('1ms')
                       maxConcurrentStreams:
-                        description: The maximum number of concurrent streams
+                        description: The maximum number of concurrent streams 
                           allowed for a peer on one HTTP/2 connection.
                         format: int32
                         type: integer
                       maxRequestsPerConnection:
-                        description: Maximum number of requests per connection
+                        description: Maximum number of requests per connection 
                           to a backend.
                         format: int32
                         type: integer
                       maxRetries:
-                        description: Maximum number of retries that can be
+                        description: Maximum number of retries that can be 
                           outstanding to all hosts in a cluster at a given time.
                         format: int32
                         type: integer
                       useClientProtocol:
-                        description: If set to true, client protocol will be
+                        description: If set to true, client protocol will be 
                           preserved while initiating connection to backend.
                         type: boolean
                     type: object
                   tcp:
-                    description: Settings common to both HTTP and TCP upstream
+                    description: Settings common to both HTTP and TCP upstream 
                       connections.
                     properties:
                       connectTimeout:
@@ -11966,19 +11966,19 @@ spec:
                         format: int32
                         type: integer
                       tcpKeepalive:
-                        description: If set then set SO_KEEPALIVE on the socket
+                        description: If set then set SO_KEEPALIVE on the socket 
                           to enable TCP Keepalives.
                         properties:
                           interval:
-                            description: The time duration between keep-alive
+                            description: The time duration between keep-alive 
                               probes.
                             type: string
                             x-kubernetes-validations:
                             - message: must be a valid duration greater than 1ms
                               rule: duration(self) >= duration('1ms')
                           probes:
-                            description: Maximum number of keepalive probes to
-                              send without response before deciding the
+                            description: Maximum number of keepalive probes to 
+                              send without response before deciding the 
                               connection is dead.
                             maximum: 4294967295
                             minimum: 0
@@ -11994,13 +11994,13 @@ spec:
                     type: object
                 type: object
               ingress:
-                description: Ingress specifies the configuration of the sidecar
-                  for processing inbound traffic to the attached workload
+                description: Ingress specifies the configuration of the sidecar 
+                  for processing inbound traffic to the attached workload 
                   instance.
                 items:
                   properties:
                     bind:
-                      description: The IP(IPv4 or IPv6) to which the listener
+                      description: The IP(IPv4 or IPv6) to which the listener 
                         should be bound.
                       type: string
                     captureMode:
@@ -12014,7 +12014,7 @@ spec:
                       - NONE
                       type: string
                     connectionPool:
-                      description: Settings controlling the volume of
+                      description: Settings controlling the volume of 
                         connections Envoy will accept from the network.
                       properties:
                         http:
@@ -12031,32 +12031,32 @@ spec:
                               - UPGRADE
                               type: string
                             http1MaxPendingRequests:
-                              description: Maximum number of requests that will
-                                be queued while waiting for a ready connection
+                              description: Maximum number of requests that will 
+                                be queued while waiting for a ready connection 
                                 pool connection.
                               format: int32
                               type: integer
                             http2MaxRequests:
-                              description: Maximum number of active requests to
+                              description: Maximum number of active requests to 
                                 a destination.
                               format: int32
                               type: integer
                             idleTimeout:
-                              description: The idle timeout for upstream
+                              description: The idle timeout for upstream 
                                 connection pool connections.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxConcurrentStreams:
-                              description: The maximum number of concurrent
-                                streams allowed for a peer on one HTTP/2
+                              description: The maximum number of concurrent 
+                                streams allowed for a peer on one HTTP/2 
                                 connection.
                               format: int32
                               type: integer
                             maxRequestsPerConnection:
-                              description: Maximum number of requests per
+                              description: Maximum number of requests per 
                                 connection to a backend.
                               format: int32
                               type: integer
@@ -12067,20 +12067,20 @@ spec:
                               format: int32
                               type: integer
                             useClientProtocol:
-                              description: If set to true, client protocol will
-                                be preserved while initiating connection to
+                              description: If set to true, client protocol will 
+                                be preserved while initiating connection to 
                                 backend.
                               type: boolean
                           type: object
                         tcp:
-                          description: Settings common to both HTTP and TCP
+                          description: Settings common to both HTTP and TCP 
                             upstream connections.
                           properties:
                             connectTimeout:
                               description: TCP connection timeout.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             idleTimeout:
@@ -12090,47 +12090,47 @@ spec:
                               description: The maximum duration of a connection.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             maxConnections:
-                              description: Maximum number of HTTP1 /TCP
+                              description: Maximum number of HTTP1 /TCP 
                                 connections to a destination host.
                               format: int32
                               type: integer
                             tcpKeepalive:
-                              description: If set then set SO_KEEPALIVE on the
+                              description: If set then set SO_KEEPALIVE on the 
                                 socket to enable TCP Keepalives.
                               properties:
                                 interval:
-                                  description: The time duration between
+                                  description: The time duration between 
                                     keep-alive probes.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                                 probes:
-                                  description: Maximum number of keepalive
-                                    probes to send without response before
+                                  description: Maximum number of keepalive 
+                                    probes to send without response before 
                                     deciding the connection is dead.
                                   maximum: 4294967295
                                   minimum: 0
                                   type: integer
                                 time:
-                                  description: The time duration a connection
-                                    needs to be idle before keep-alive probes
+                                  description: The time duration a connection 
+                                    needs to be idle before keep-alive probes 
                                     start being sent.
                                   type: string
                                   x-kubernetes-validations:
-                                  - message: must be a valid duration greater
+                                  - message: must be a valid duration greater 
                                       than 1ms
                                     rule: duration(self) >= duration('1ms')
                               type: object
                           type: object
                       type: object
                     defaultEndpoint:
-                      description: The IP endpoint or Unix domain socket to
+                      description: The IP endpoint or Unix domain socket to 
                         which traffic should be forwarded to.
                       type: string
                     port:
@@ -12153,8 +12153,8 @@ spec:
                           type: integer
                       type: object
                     tls:
-                      description: Set of TLS related options that will enable
-                        TLS termination on the sidecar for requests originating
+                      description: Set of TLS related options that will enable 
+                        TLS termination on the sidecar for requests originating 
                         from outside the mesh.
                       properties:
                         caCertCredentialName:
@@ -12162,7 +12162,7 @@ spec:
                             the configmap that holds CA certificates.
                           type: string
                         caCertificates:
-                          description: REQUIRED if mode is `MUTUAL` or
+                          description: REQUIRED if mode is `MUTUAL` or 
                             `OPTIONAL_MUTUAL`.
                           type: string
                         caCrl:
@@ -12177,12 +12177,12 @@ spec:
                             type: string
                           type: array
                         credentialName:
-                          description: For gateways running on Kubernetes, the
-                            name of the secret that holds the TLS certs
+                          description: For gateways running on Kubernetes, the 
+                            name of the secret that holds the TLS certs 
                             including the CA certificates.
                           type: string
                         credentialNames:
-                          description: Same as CredentialName but for multiple
+                          description: Same as CredentialName but for multiple 
                             certificates.
                           items:
                             type: string
@@ -12190,7 +12190,7 @@ spec:
                           minItems: 1
                           type: array
                         httpsRedirect:
-                          description: If set to true, the load balancer will
+                          description: If set to true, the load balancer will 
                             send a 301 redirect for all http connections, asking
                             the clients to use HTTPS.
                           type: boolean
@@ -12238,27 +12238,27 @@ spec:
                           description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
                           type: string
                         subjectAltNames:
-                          description: A list of alternate names to verify the
+                          description: A list of alternate names to verify the 
                             subject identity in the certificate presented by the
                             client.
                           items:
                             type: string
                           type: array
                         tlsCertificates:
-                          description: Only one of `server_certificate`,
-                            `private_key` or `credential_name` or
-                            `credential_names` or `tls_certificates` should be
+                          description: Only one of `server_certificate`, 
+                            `private_key` or `credential_name` or 
+                            `credential_names` or `tls_certificates` should be 
                             specified.
                           items:
                             properties:
                               caCertificates:
                                 type: string
                               privateKey:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                               serverCertificate:
-                                description: REQUIRED if mode is `SIMPLE` or
+                                description: REQUIRED if mode is `SIMPLE` or 
                                   `MUTUAL`.
                                 type: string
                             type: object
@@ -12266,29 +12266,29 @@ spec:
                           minItems: 1
                           type: array
                         verifyCertificateHash:
-                          description: An optional list of hex-encoded SHA-256
+                          description: An optional list of hex-encoded SHA-256 
                             hashes of the authorized client certificates.
                           items:
                             type: string
                           type: array
                         verifyCertificateSpki:
-                          description: An optional list of base64-encoded
-                            SHA-256 hashes of the SPKIs of authorized client
+                          description: An optional list of base64-encoded 
+                            SHA-256 hashes of the SPKIs of authorized client 
                             certificates.
                           items:
                             type: string
                           type: array
                       type: object
                       x-kubernetes-validations:
-                      - message: only one of credentialNames or tlsCertificates
+                      - message: only one of credentialNames or tlsCertificates 
                           can be set
                         rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or credentialNames
+                      - message: only one of credentialName or credentialNames 
                           can be set
                         rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
                           ? 1 : 0) <= 1'
-                      - message: only one of credentialName or tlsCertificates
+                      - message: only one of credentialName or tlsCertificates 
                           can be set
                         rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
                           ? 1 : 0) <= 1'
@@ -12297,17 +12297,17 @@ spec:
                   type: object
                 type: array
               outboundTrafficPolicy:
-                description: Set the default behavior of the sidecar for
+                description: Set the default behavior of the sidecar for 
                   handling outbound traffic from the application.
                 properties:
                   egressProxy:
                     properties:
                       host:
-                        description: The name of a service from the service
+                        description: The name of a service from the service 
                           registry.
                         type: string
                       port:
-                        description: Specifies the port on the host that is
+                        description: Specifies the port on the host that is 
                           being addressed.
                         properties:
                           number:
@@ -12332,8 +12332,8 @@ spec:
                     type: string
                 type: object
               workloadSelector:
-                description: Criteria used to select the specific set of
-                  pods/VMs on which this `Sidecar` configuration should be
+                description: Criteria used to select the specific set of 
+                  pods/VMs on which this `Sidecar` configuration should be 
                   applied.
                 properties:
                   labels:
@@ -12365,18 +12365,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -12415,12 +12415,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -12490,12 +12490,12 @@ spec:
                       description: Optional.
                       properties:
                         expression:
-                          description: CEL expression for selecting when
+                          description: CEL expression for selecting when 
                             requests/connections should be logged.
                           type: string
                       type: object
                     match:
-                      description: Allows tailoring of logging behavior to
+                      description: Allows tailoring of logging behavior to 
                         specific conditions.
                       properties:
                         mode:
@@ -12597,12 +12597,12 @@ spec:
                                   - REMOVE
                                   type: string
                                 value:
-                                  description: Value is only considered if the
+                                  description: Value is only considered if the 
                                     operation is `UPSERT`.
                                   type: string
                               type: object
                               x-kubernetes-validations:
-                              - message: value must be set when operation is
+                              - message: value must be set when operation is 
                                   UPSERT
                                 rule: '((has(self.operation) ? self.operation : "")
                                   == "UPSERT") ? (self.value != "") : true'
@@ -12659,7 +12659,7 @@ spec:
                   group:
                     description: group is the group of the target resource.
                     maxLength: 253
-                    pattern:
+                    pattern: 
                       ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
@@ -12677,7 +12677,7 @@ spec:
                     description: namespace is the namespace of the referent.
                     type: string
                     x-kubernetes-validations:
-                    - message: cross namespace referencing is not currently
+                    - message: cross namespace referencing is not currently 
                         supported
                       rule: self.size() == 0
                 required:
@@ -12691,7 +12691,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -12709,7 +12709,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -12745,14 +12745,14 @@ spec:
                           - formatter
                         properties:
                           environment:
-                            description: Environment adds the value of an
+                            description: Environment adds the value of an 
                               environment variable to each span.
                             properties:
                               defaultValue:
                                 description: Optional.
                                 type: string
                               name:
-                                description: Name of the environment variable
+                                description: Name of the environment variable 
                                   from which to extract the tag value.
                                 minLength: 1
                                 type: string
@@ -12760,11 +12760,11 @@ spec:
                             - name
                             type: object
                           formatter:
-                            description: Formatter adds the value of access
+                            description: Formatter adds the value of access 
                               logging substitution formatter.
                             properties:
                               value:
-                                description: The formatter tag value to use,
+                                description: The formatter tag value to use, 
                                   same formatter as HTTP access logging (e.g.
                                 minLength: 1
                                 type: string
@@ -12772,14 +12772,14 @@ spec:
                             - value
                             type: object
                           header:
-                            description: RequestHeader adds the value of an
+                            description: RequestHeader adds the value of an 
                               header from the request to each span.
                             properties:
                               defaultValue:
                                 description: Optional.
                                 type: string
                               name:
-                                description: Name of the header from which to
+                                description: Name of the header from which to 
                                   extract the tag value.
                                 minLength: 1
                                 type: string
@@ -12811,12 +12811,12 @@ spec:
                       nullable: true
                       type: boolean
                     enableIstioTags:
-                      description: Determines whether or not trace spans
+                      description: Determines whether or not trace spans 
                         generated by Envoy will include Istio specific tags.
                       nullable: true
                       type: boolean
                     match:
-                      description: Allows tailoring of behavior to specific
+                      description: Allows tailoring of behavior to specific 
                         conditions.
                       properties:
                         mode:
@@ -12843,8 +12843,8 @@ spec:
                         type: object
                       type: array
                     randomSamplingPercentage:
-                      description: Controls the rate at which traffic will be
-                        selected for tracing if no prior sampling decision has
+                      description: Controls the rate at which traffic will be 
+                        selected for tracing if no prior sampling decision has 
                         been made.
                       format: double
                       maximum: 100
@@ -12877,18 +12877,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -12927,12 +12927,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -12974,12 +12974,12 @@ spec:
                       description: Optional.
                       properties:
                         expression:
-                          description: CEL expression for selecting when
+                          description: CEL expression for selecting when 
                             requests/connections should be logged.
                           type: string
                       type: object
                     match:
-                      description: Allows tailoring of logging behavior to
+                      description: Allows tailoring of logging behavior to 
                         specific conditions.
                       properties:
                         mode:
@@ -13081,12 +13081,12 @@ spec:
                                   - REMOVE
                                   type: string
                                 value:
-                                  description: Value is only considered if the
+                                  description: Value is only considered if the 
                                     operation is `UPSERT`.
                                   type: string
                               type: object
                               x-kubernetes-validations:
-                              - message: value must be set when operation is
+                              - message: value must be set when operation is 
                                   UPSERT
                                 rule: '((has(self.operation) ? self.operation : "")
                                   == "UPSERT") ? (self.value != "") : true'
@@ -13143,7 +13143,7 @@ spec:
                   group:
                     description: group is the group of the target resource.
                     maxLength: 253
-                    pattern:
+                    pattern: 
                       ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
@@ -13161,7 +13161,7 @@ spec:
                     description: namespace is the namespace of the referent.
                     type: string
                     x-kubernetes-validations:
-                    - message: cross namespace referencing is not currently
+                    - message: cross namespace referencing is not currently 
                         supported
                       rule: self.size() == 0
                 required:
@@ -13175,7 +13175,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -13193,7 +13193,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -13229,14 +13229,14 @@ spec:
                           - formatter
                         properties:
                           environment:
-                            description: Environment adds the value of an
+                            description: Environment adds the value of an 
                               environment variable to each span.
                             properties:
                               defaultValue:
                                 description: Optional.
                                 type: string
                               name:
-                                description: Name of the environment variable
+                                description: Name of the environment variable 
                                   from which to extract the tag value.
                                 minLength: 1
                                 type: string
@@ -13244,11 +13244,11 @@ spec:
                             - name
                             type: object
                           formatter:
-                            description: Formatter adds the value of access
+                            description: Formatter adds the value of access 
                               logging substitution formatter.
                             properties:
                               value:
-                                description: The formatter tag value to use,
+                                description: The formatter tag value to use, 
                                   same formatter as HTTP access logging (e.g.
                                 minLength: 1
                                 type: string
@@ -13256,14 +13256,14 @@ spec:
                             - value
                             type: object
                           header:
-                            description: RequestHeader adds the value of an
+                            description: RequestHeader adds the value of an 
                               header from the request to each span.
                             properties:
                               defaultValue:
                                 description: Optional.
                                 type: string
                               name:
-                                description: Name of the header from which to
+                                description: Name of the header from which to 
                                   extract the tag value.
                                 minLength: 1
                                 type: string
@@ -13295,12 +13295,12 @@ spec:
                       nullable: true
                       type: boolean
                     enableIstioTags:
-                      description: Determines whether or not trace spans
+                      description: Determines whether or not trace spans 
                         generated by Envoy will include Istio specific tags.
                       nullable: true
                       type: boolean
                     match:
-                      description: Allows tailoring of behavior to specific
+                      description: Allows tailoring of behavior to specific 
                         conditions.
                       properties:
                         mode:
@@ -13327,8 +13327,8 @@ spec:
                         type: object
                       type: array
                     randomSamplingPercentage:
-                      description: Controls the rate at which traffic will be
-                        selected for tracing if no prior sampling decision has
+                      description: Controls the rate at which traffic will be 
+                        selected for tracing if no prior sampling decision has 
                         been made.
                       format: double
                       maximum: 100
@@ -13361,18 +13361,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -13411,12 +13411,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -13495,7 +13495,7 @@ spec:
                 - inlineCode
                 type: object
               match:
-                description: Specifies the criteria to determine which traffic
+                description: Specifies the criteria to determine which traffic 
                   is passed to TrafficExtension.
                 items:
                   properties:
@@ -13511,7 +13511,7 @@ spec:
                       - CLIENT_AND_SERVER
                       type: string
                     ports:
-                      description: Criteria for selecting traffic by their
+                      description: Criteria for selecting traffic by their 
                         destination port.
                       items:
                         properties:
@@ -13540,7 +13540,7 @@ spec:
                 - STATS
                 type: string
               priority:
-                description: Determines ordering of `TrafficExtensions` in the
+                description: Determines ordering of `TrafficExtensions` in the 
                   same `phase`.
                 format: int32
                 nullable: true
@@ -13572,7 +13572,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -13590,7 +13590,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -13633,13 +13633,13 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   pluginName:
-                    description: The plugin name to be used in the Envoy
+                    description: The plugin name to be used in the Envoy 
                       configuration (used to be called `rootID`).
                     maxLength: 256
                     minLength: 1
                     type: string
                   sha256:
-                    description: SHA256 checksum that will be used to verify
+                    description: SHA256 checksum that will be used to verify 
                       Wasm module or OCI container.
                     pattern: (^$|^[a-f0-9]{64}$)
                     type: string
@@ -13658,7 +13658,7 @@ spec:
                     minLength: 1
                     type: string
                     x-kubernetes-validations:
-                    - message: url must have schema one of [http, https, file,
+                    - message: url must have schema one of [http, https, file, 
                         oci]
                       rule: |-
                         isURL(self) ? (url(self).getScheme() in ["", "http", "https", "file", "oci"]) : (isURL("http://" + self) &&
@@ -13669,7 +13669,7 @@ spec:
                     description: Configuration for a Wasm VM.
                     properties:
                       env:
-                        description: Specifies environment variables to be
+                        description: Specifies environment variables to be 
                           injected to this VM.
                         items:
                           properties:
@@ -13695,7 +13695,7 @@ spec:
                           - name
                           type: object
                           x-kubernetes-validations:
-                          - message: value may only be set when valueFrom is
+                          - message: value may only be set when valueFrom is 
                               INLINE
                             rule: '(has(self.valueFrom) ? self.valueFrom : "") !=
                               "HOST" || !has(self.value)'
@@ -13731,18 +13731,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -13781,12 +13781,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -13830,7 +13830,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The names of gateways and sidecars that should apply these
+    - description: The names of gateways and sidecars that should apply these 
         routes
       jsonPath: .spec.gateways
       name: Gateways
@@ -13856,19 +13856,19 @@ spec:
               etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
             properties:
               exportTo:
-                description: A list of namespaces to which this virtual service
+                description: A list of namespaces to which this virtual service 
                   is exported.
                 items:
                   type: string
                 type: array
               gateways:
-                description: The names of gateways and sidecars that should
+                description: The names of gateways and sidecars that should 
                   apply these routes.
                 items:
                   type: string
                 type: array
               hosts:
-                description: The destination hosts to which traffic is being
+                description: The destination hosts to which traffic is being 
                   sent.
                 items:
                   type: string
@@ -13881,19 +13881,19 @@ spec:
                       description: Cross-Origin Resource Sharing policy (CORS).
                       properties:
                         allowCredentials:
-                          description: Indicates whether the caller is allowed
+                          description: Indicates whether the caller is allowed 
                             to send the actual request (not the preflight) using
                             credentials.
                           nullable: true
                           type: boolean
                         allowHeaders:
-                          description: List of HTTP headers that can be used
+                          description: List of HTTP headers that can be used 
                             when requesting the resource.
                           items:
                             type: string
                           type: array
                         allowMethods:
-                          description: List of HTTP methods allowed to access
+                          description: List of HTTP methods allowed to access 
                             the resource.
                           items:
                             type: string
@@ -13903,7 +13903,7 @@ spec:
                             type: string
                           type: array
                         allowOrigins:
-                          description: String patterns that match allowed
+                          description: String patterns that match allowed 
                             origins.
                           items:
                             oneOf:
@@ -13932,13 +13932,13 @@ spec:
                             type: object
                           type: array
                         exposeHeaders:
-                          description: A list of HTTP headers that the browsers
+                          description: A list of HTTP headers that the browsers 
                             are allowed to access.
                           items:
                             type: string
                           type: array
                         maxAge:
-                          description: Specifies how long the results of a
+                          description: Specifies how long the results of a 
                             preflight request can be cached.
                           type: string
                           x-kubernetes-validations:
@@ -13956,25 +13956,25 @@ spec:
                           type: string
                       type: object
                     delegate:
-                      description: Delegate is used to specify the particular
-                        VirtualService which can be used to define delegate
+                      description: Delegate is used to specify the particular 
+                        VirtualService which can be used to define delegate 
                         HTTPRoute.
                       properties:
                         name:
-                          description: Name specifies the name of the delegate
+                          description: Name specifies the name of the delegate 
                             VirtualService.
                           type: string
                         namespace:
-                          description: Namespace specifies the namespace where
+                          description: Namespace specifies the namespace where 
                             the delegate VirtualService resides.
                           type: string
                       type: object
                     directResponse:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       properties:
                         body:
-                          description: Specifies the content of the response
+                          description: Specifies the content of the response 
                             body.
                           oneOf:
                           - not:
@@ -13989,7 +13989,7 @@ spec:
                             - bytes
                           properties:
                             bytes:
-                              description: response body as base64 encoded
+                              description: response body as base64 encoded 
                                 bytes.
                               format: byte
                               type: string
@@ -13997,7 +13997,7 @@ spec:
                               type: string
                           type: object
                         status:
-                          description: Specifies the HTTP response status to be
+                          description: Specifies the HTTP response status to be 
                             returned.
                           maximum: 4294967295
                           minimum: 0
@@ -14006,12 +14006,12 @@ spec:
                       - status
                       type: object
                     fault:
-                      description: Fault injection policy to apply on HTTP
+                      description: Fault injection policy to apply on HTTP 
                         traffic at the client side.
                       properties:
                         abort:
-                          description: Abort Http request attempts and return
-                            error codes back to downstream service, giving the
+                          description: Abort Http request attempts and return 
+                            error codes back to downstream service, giving the 
                             impression that the upstream service is faulty.
                           oneOf:
                           - not:
@@ -14030,18 +14030,18 @@ spec:
                             - http2Error
                           properties:
                             grpcStatus:
-                              description: GRPC status code to use to abort the
+                              description: GRPC status code to use to abort the 
                                 request.
                               type: string
                             http2Error:
                               type: string
                             httpStatus:
-                              description: HTTP status code to use to abort the
+                              description: HTTP status code to use to abort the 
                                 Http request.
                               format: int32
                               type: integer
                             percentage:
-                              description: Percentage of requests to be aborted
+                              description: Percentage of requests to be aborted 
                                 with the error code provided.
                               properties:
                                 value:
@@ -14050,8 +14050,8 @@ spec:
                               type: object
                           type: object
                         delay:
-                          description: Delay requests before forwarding,
-                            emulating various failures such as network issues,
+                          description: Delay requests before forwarding, 
+                            emulating various failures such as network issues, 
                             overloaded upstream service, etc.
                           oneOf:
                           - not:
@@ -14068,24 +14068,24 @@ spec:
                             exponentialDelay:
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             fixedDelay:
-                              description: Add a fixed delay before forwarding
+                              description: Add a fixed delay before forwarding 
                                 the request.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             percent:
-                              description: Percentage of requests on which the
+                              description: Percentage of requests on which the 
                                 delay will be injected (0-100).
                               format: int32
                               type: integer
                             percentage:
-                              description: Percentage of requests on which the
+                              description: Percentage of requests on which the 
                                 delay will be injected.
                               properties:
                                 value:
@@ -14193,11 +14193,11 @@ spec:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                                   type: string
                               type: object
-                            description: The header keys must be lowercase and
+                            description: The header keys must be lowercase and 
                               use hyphen as the separator, e.g.
                             type: object
                           ignoreUriCase:
-                            description: Flag to specify whether the URI
+                            description: Flag to specify whether the URI 
                               matching should be case-insensitive.
                             type: boolean
                           method:
@@ -14298,17 +14298,17 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to source (client)
+                            description: One or more labels that constrain the 
+                              applicability of a rule to source (client) 
                               workloads with the given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                           statPrefix:
-                            description: The human readable prefix to use when
+                            description: The human readable prefix to use when 
                               emitting statistics for this route.
                             type: string
                           uri:
@@ -14366,22 +14366,22 @@ spec:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                                   type: string
                               type: object
-                            description: withoutHeader has the same syntax with
+                            description: withoutHeader has the same syntax with 
                               the header, but has opposite meaning.
                             type: object
                         type: object
                       type: array
                     mirror:
-                      description: Mirror HTTP traffic to a another destination
-                        in addition to forwarding the requests to the intended
+                      description: Mirror HTTP traffic to a another destination 
+                        in addition to forwarding the requests to the intended 
                         destination.
                       properties:
                         host:
-                          description: The name of a service from the service
+                          description: The name of a service from the service 
                             registry.
                           type: string
                         port:
-                          description: Specifies the port on the host that is
+                          description: Specifies the port on the host that is 
                             being addressed.
                           properties:
                             number:
@@ -14406,7 +14406,7 @@ spec:
                       nullable: true
                       type: integer
                     mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by
+                      description: Percentage of the traffic to be mirrored by 
                         the `mirror` field.
                       properties:
                         value:
@@ -14414,7 +14414,7 @@ spec:
                           type: number
                       type: object
                     mirrors:
-                      description: Specifies the destinations to mirror HTTP
+                      description: Specifies the destinations to mirror HTTP 
                         traffic in addition to the original destination.
                       items:
                         properties:
@@ -14423,7 +14423,7 @@ spec:
                               mirror operation.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -14436,14 +14436,14 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           percentage:
-                            description: Percentage of the traffic to be
+                            description: Percentage of the traffic to be 
                               mirrored by the `destination` field.
                             properties:
                               value:
@@ -14455,11 +14455,11 @@ spec:
                         type: object
                       type: array
                     name:
-                      description: The name assigned to the route for debugging
+                      description: The name assigned to the route for debugging 
                         purposes.
                       type: string
                     redirect:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       oneOf:
                       - not:
@@ -14474,7 +14474,7 @@ spec:
                         - derivePort
                       properties:
                         authority:
-                          description: On a redirect, overwrite the
+                          description: On a redirect, overwrite the 
                             Authority/Host portion of the URL with this value.
                           type: string
                         derivePort:
@@ -14493,13 +14493,13 @@ spec:
                           minimum: 0
                           type: integer
                         redirectCode:
-                          description: On a redirect, Specifies the HTTP status
+                          description: On a redirect, Specifies the HTTP status 
                             code to use in the redirect response.
                           maximum: 4294967295
                           minimum: 0
                           type: integer
                         scheme:
-                          description: On a redirect, overwrite the scheme
+                          description: On a redirect, overwrite the scheme 
                             portion of the URL with this value.
                           type: string
                         uri:
@@ -14511,35 +14511,35 @@ spec:
                       description: Retry policy for HTTP requests.
                       properties:
                         attempts:
-                          description: Number of retries to be allowed for a
+                          description: Number of retries to be allowed for a 
                             given request.
                           format: int32
                           type: integer
                         backoff:
-                          description: Specifies the minimum duration between
+                          description: Specifies the minimum duration between 
                             retry attempts.
                           type: string
                           x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
                         perTryTimeout:
-                          description: Timeout per attempt for a given request,
+                          description: Timeout per attempt for a given request, 
                             including the initial call and any retries.
                           type: string
                           x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
                         retryIgnorePreviousHosts:
-                          description: Flag to specify whether the retries
+                          description: Flag to specify whether the retries 
                             should ignore previously tried hosts during retry.
                           nullable: true
                           type: boolean
                         retryOn:
-                          description: Specifies the conditions under which
+                          description: Specifies the conditions under which 
                             retry takes place.
                           type: string
                         retryRemoteLocalities:
-                          description: Flag to specify whether the retries
+                          description: Flag to specify whether the retries 
                             should retry to other localities.
                           nullable: true
                           type: boolean
@@ -14548,38 +14548,38 @@ spec:
                       description: Rewrite HTTP URIs and Authority headers.
                       properties:
                         authority:
-                          description: rewrite the Authority/Host header with
+                          description: rewrite the Authority/Host header with 
                             this value.
                           type: string
                         uri:
-                          description: rewrite the path (or the prefix) portion
+                          description: rewrite the path (or the prefix) portion 
                             of the URI with this value.
                           type: string
                         uriRegexRewrite:
-                          description: rewrite the path portion of the URI with
+                          description: rewrite the path portion of the URI with 
                             the specified regex.
                           properties:
                             match:
                               description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                               type: string
                             rewrite:
-                              description: The string that should replace into
+                              description: The string that should replace into 
                                 matching portions of original URI.
                               type: string
                           type: object
                       type: object
                     route:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -14592,7 +14592,7 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
@@ -14632,8 +14632,8 @@ spec:
                                 type: object
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -14642,7 +14642,7 @@ spec:
                         type: object
                       type: array
                     timeout:
-                      description: Timeout for HTTP requests, default is
+                      description: Timeout for HTTP requests, default is 
                         disabled.
                       type: string
                       x-kubernetes-validations:
@@ -14651,7 +14651,7 @@ spec:
                   type: object
                 type: array
               tcp:
-                description: An ordered list of route rules for opaque TCP
+                description: An ordered list of route rules for opaque TCP 
                   traffic.
                 items:
                   properties:
@@ -14661,7 +14661,7 @@ spec:
                       items:
                         properties:
                           destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of
+                            description: IPv4 or IPv6 ip addresses of 
                               destination with optional subnet.
                             items:
                               type: string
@@ -14673,7 +14673,7 @@ spec:
                               type: string
                             type: array
                           port:
-                            description: Specifies the port on the host that is
+                            description: Specifies the port on the host that is 
                               being addressed.
                             maximum: 4294967295
                             minimum: 0
@@ -14681,13 +14681,13 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to workloads with the
+                            description: One or more labels that constrain the 
+                              applicability of a rule to workloads with the 
                               given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                           sourceSubnet:
@@ -14695,17 +14695,17 @@ spec:
                         type: object
                       type: array
                     route:
-                      description: The destination to which the connection
+                      description: The destination to which the connection 
                         should be forwarded to.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -14718,15 +14718,15 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -14737,7 +14737,7 @@ spec:
                   type: object
                 type: array
               tls:
-                description: An ordered list of route rule for non-terminated
+                description: An ordered list of route rule for non-terminated 
                   TLS & HTTPS traffic.
                 items:
                   properties:
@@ -14747,7 +14747,7 @@ spec:
                       items:
                         properties:
                           destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of
+                            description: IPv4 or IPv6 ip addresses of 
                               destination with optional subnet.
                             items:
                               type: string
@@ -14759,13 +14759,13 @@ spec:
                               type: string
                             type: array
                           port:
-                            description: Specifies the port on the host that is
+                            description: Specifies the port on the host that is 
                               being addressed.
                             maximum: 4294967295
                             minimum: 0
                             type: integer
                           sniHosts:
-                            description: SNI (server name indicator) to match
+                            description: SNI (server name indicator) to match 
                               on.
                             items:
                               type: string
@@ -14773,13 +14773,13 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to workloads with the
+                            description: One or more labels that constrain the 
+                              applicability of a rule to workloads with the 
                               given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                         required:
@@ -14787,17 +14787,17 @@ spec:
                         type: object
                       type: array
                     route:
-                      description: The destination to which the connection
+                      description: The destination to which the connection 
                         should be forwarded to.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -14810,15 +14810,15 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -14847,18 +14847,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -14897,12 +14897,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -14916,7 +14916,7 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: The names of gateways and sidecars that should apply these
+    - description: The names of gateways and sidecars that should apply these 
         routes
       jsonPath: .spec.gateways
       name: Gateways
@@ -14942,19 +14942,19 @@ spec:
               etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
             properties:
               exportTo:
-                description: A list of namespaces to which this virtual service
+                description: A list of namespaces to which this virtual service 
                   is exported.
                 items:
                   type: string
                 type: array
               gateways:
-                description: The names of gateways and sidecars that should
+                description: The names of gateways and sidecars that should 
                   apply these routes.
                 items:
                   type: string
                 type: array
               hosts:
-                description: The destination hosts to which traffic is being
+                description: The destination hosts to which traffic is being 
                   sent.
                 items:
                   type: string
@@ -14967,19 +14967,19 @@ spec:
                       description: Cross-Origin Resource Sharing policy (CORS).
                       properties:
                         allowCredentials:
-                          description: Indicates whether the caller is allowed
+                          description: Indicates whether the caller is allowed 
                             to send the actual request (not the preflight) using
                             credentials.
                           nullable: true
                           type: boolean
                         allowHeaders:
-                          description: List of HTTP headers that can be used
+                          description: List of HTTP headers that can be used 
                             when requesting the resource.
                           items:
                             type: string
                           type: array
                         allowMethods:
-                          description: List of HTTP methods allowed to access
+                          description: List of HTTP methods allowed to access 
                             the resource.
                           items:
                             type: string
@@ -14989,7 +14989,7 @@ spec:
                             type: string
                           type: array
                         allowOrigins:
-                          description: String patterns that match allowed
+                          description: String patterns that match allowed 
                             origins.
                           items:
                             oneOf:
@@ -15018,13 +15018,13 @@ spec:
                             type: object
                           type: array
                         exposeHeaders:
-                          description: A list of HTTP headers that the browsers
+                          description: A list of HTTP headers that the browsers 
                             are allowed to access.
                           items:
                             type: string
                           type: array
                         maxAge:
-                          description: Specifies how long the results of a
+                          description: Specifies how long the results of a 
                             preflight request can be cached.
                           type: string
                           x-kubernetes-validations:
@@ -15042,25 +15042,25 @@ spec:
                           type: string
                       type: object
                     delegate:
-                      description: Delegate is used to specify the particular
-                        VirtualService which can be used to define delegate
+                      description: Delegate is used to specify the particular 
+                        VirtualService which can be used to define delegate 
                         HTTPRoute.
                       properties:
                         name:
-                          description: Name specifies the name of the delegate
+                          description: Name specifies the name of the delegate 
                             VirtualService.
                           type: string
                         namespace:
-                          description: Namespace specifies the namespace where
+                          description: Namespace specifies the namespace where 
                             the delegate VirtualService resides.
                           type: string
                       type: object
                     directResponse:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       properties:
                         body:
-                          description: Specifies the content of the response
+                          description: Specifies the content of the response 
                             body.
                           oneOf:
                           - not:
@@ -15075,7 +15075,7 @@ spec:
                             - bytes
                           properties:
                             bytes:
-                              description: response body as base64 encoded
+                              description: response body as base64 encoded 
                                 bytes.
                               format: byte
                               type: string
@@ -15083,7 +15083,7 @@ spec:
                               type: string
                           type: object
                         status:
-                          description: Specifies the HTTP response status to be
+                          description: Specifies the HTTP response status to be 
                             returned.
                           maximum: 4294967295
                           minimum: 0
@@ -15092,12 +15092,12 @@ spec:
                       - status
                       type: object
                     fault:
-                      description: Fault injection policy to apply on HTTP
+                      description: Fault injection policy to apply on HTTP 
                         traffic at the client side.
                       properties:
                         abort:
-                          description: Abort Http request attempts and return
-                            error codes back to downstream service, giving the
+                          description: Abort Http request attempts and return 
+                            error codes back to downstream service, giving the 
                             impression that the upstream service is faulty.
                           oneOf:
                           - not:
@@ -15116,18 +15116,18 @@ spec:
                             - http2Error
                           properties:
                             grpcStatus:
-                              description: GRPC status code to use to abort the
+                              description: GRPC status code to use to abort the 
                                 request.
                               type: string
                             http2Error:
                               type: string
                             httpStatus:
-                              description: HTTP status code to use to abort the
+                              description: HTTP status code to use to abort the 
                                 Http request.
                               format: int32
                               type: integer
                             percentage:
-                              description: Percentage of requests to be aborted
+                              description: Percentage of requests to be aborted 
                                 with the error code provided.
                               properties:
                                 value:
@@ -15136,8 +15136,8 @@ spec:
                               type: object
                           type: object
                         delay:
-                          description: Delay requests before forwarding,
-                            emulating various failures such as network issues,
+                          description: Delay requests before forwarding, 
+                            emulating various failures such as network issues, 
                             overloaded upstream service, etc.
                           oneOf:
                           - not:
@@ -15154,24 +15154,24 @@ spec:
                             exponentialDelay:
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             fixedDelay:
-                              description: Add a fixed delay before forwarding
+                              description: Add a fixed delay before forwarding 
                                 the request.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             percent:
-                              description: Percentage of requests on which the
+                              description: Percentage of requests on which the 
                                 delay will be injected (0-100).
                               format: int32
                               type: integer
                             percentage:
-                              description: Percentage of requests on which the
+                              description: Percentage of requests on which the 
                                 delay will be injected.
                               properties:
                                 value:
@@ -15279,11 +15279,11 @@ spec:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                                   type: string
                               type: object
-                            description: The header keys must be lowercase and
+                            description: The header keys must be lowercase and 
                               use hyphen as the separator, e.g.
                             type: object
                           ignoreUriCase:
-                            description: Flag to specify whether the URI
+                            description: Flag to specify whether the URI 
                               matching should be case-insensitive.
                             type: boolean
                           method:
@@ -15384,17 +15384,17 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to source (client)
+                            description: One or more labels that constrain the 
+                              applicability of a rule to source (client) 
                               workloads with the given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                           statPrefix:
-                            description: The human readable prefix to use when
+                            description: The human readable prefix to use when 
                               emitting statistics for this route.
                             type: string
                           uri:
@@ -15452,22 +15452,22 @@ spec:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                                   type: string
                               type: object
-                            description: withoutHeader has the same syntax with
+                            description: withoutHeader has the same syntax with 
                               the header, but has opposite meaning.
                             type: object
                         type: object
                       type: array
                     mirror:
-                      description: Mirror HTTP traffic to a another destination
-                        in addition to forwarding the requests to the intended
+                      description: Mirror HTTP traffic to a another destination 
+                        in addition to forwarding the requests to the intended 
                         destination.
                       properties:
                         host:
-                          description: The name of a service from the service
+                          description: The name of a service from the service 
                             registry.
                           type: string
                         port:
-                          description: Specifies the port on the host that is
+                          description: Specifies the port on the host that is 
                             being addressed.
                           properties:
                             number:
@@ -15492,7 +15492,7 @@ spec:
                       nullable: true
                       type: integer
                     mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by
+                      description: Percentage of the traffic to be mirrored by 
                         the `mirror` field.
                       properties:
                         value:
@@ -15500,7 +15500,7 @@ spec:
                           type: number
                       type: object
                     mirrors:
-                      description: Specifies the destinations to mirror HTTP
+                      description: Specifies the destinations to mirror HTTP 
                         traffic in addition to the original destination.
                       items:
                         properties:
@@ -15509,7 +15509,7 @@ spec:
                               mirror operation.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -15522,14 +15522,14 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           percentage:
-                            description: Percentage of the traffic to be
+                            description: Percentage of the traffic to be 
                               mirrored by the `destination` field.
                             properties:
                               value:
@@ -15541,11 +15541,11 @@ spec:
                         type: object
                       type: array
                     name:
-                      description: The name assigned to the route for debugging
+                      description: The name assigned to the route for debugging 
                         purposes.
                       type: string
                     redirect:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       oneOf:
                       - not:
@@ -15560,7 +15560,7 @@ spec:
                         - derivePort
                       properties:
                         authority:
-                          description: On a redirect, overwrite the
+                          description: On a redirect, overwrite the 
                             Authority/Host portion of the URL with this value.
                           type: string
                         derivePort:
@@ -15579,13 +15579,13 @@ spec:
                           minimum: 0
                           type: integer
                         redirectCode:
-                          description: On a redirect, Specifies the HTTP status
+                          description: On a redirect, Specifies the HTTP status 
                             code to use in the redirect response.
                           maximum: 4294967295
                           minimum: 0
                           type: integer
                         scheme:
-                          description: On a redirect, overwrite the scheme
+                          description: On a redirect, overwrite the scheme 
                             portion of the URL with this value.
                           type: string
                         uri:
@@ -15597,35 +15597,35 @@ spec:
                       description: Retry policy for HTTP requests.
                       properties:
                         attempts:
-                          description: Number of retries to be allowed for a
+                          description: Number of retries to be allowed for a 
                             given request.
                           format: int32
                           type: integer
                         backoff:
-                          description: Specifies the minimum duration between
+                          description: Specifies the minimum duration between 
                             retry attempts.
                           type: string
                           x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
                         perTryTimeout:
-                          description: Timeout per attempt for a given request,
+                          description: Timeout per attempt for a given request, 
                             including the initial call and any retries.
                           type: string
                           x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
                         retryIgnorePreviousHosts:
-                          description: Flag to specify whether the retries
+                          description: Flag to specify whether the retries 
                             should ignore previously tried hosts during retry.
                           nullable: true
                           type: boolean
                         retryOn:
-                          description: Specifies the conditions under which
+                          description: Specifies the conditions under which 
                             retry takes place.
                           type: string
                         retryRemoteLocalities:
-                          description: Flag to specify whether the retries
+                          description: Flag to specify whether the retries 
                             should retry to other localities.
                           nullable: true
                           type: boolean
@@ -15634,38 +15634,38 @@ spec:
                       description: Rewrite HTTP URIs and Authority headers.
                       properties:
                         authority:
-                          description: rewrite the Authority/Host header with
+                          description: rewrite the Authority/Host header with 
                             this value.
                           type: string
                         uri:
-                          description: rewrite the path (or the prefix) portion
+                          description: rewrite the path (or the prefix) portion 
                             of the URI with this value.
                           type: string
                         uriRegexRewrite:
-                          description: rewrite the path portion of the URI with
+                          description: rewrite the path portion of the URI with 
                             the specified regex.
                           properties:
                             match:
                               description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                               type: string
                             rewrite:
-                              description: The string that should replace into
+                              description: The string that should replace into 
                                 matching portions of original URI.
                               type: string
                           type: object
                       type: object
                     route:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -15678,7 +15678,7 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
@@ -15718,8 +15718,8 @@ spec:
                                 type: object
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -15728,7 +15728,7 @@ spec:
                         type: object
                       type: array
                     timeout:
-                      description: Timeout for HTTP requests, default is
+                      description: Timeout for HTTP requests, default is 
                         disabled.
                       type: string
                       x-kubernetes-validations:
@@ -15737,7 +15737,7 @@ spec:
                   type: object
                 type: array
               tcp:
-                description: An ordered list of route rules for opaque TCP
+                description: An ordered list of route rules for opaque TCP 
                   traffic.
                 items:
                   properties:
@@ -15747,7 +15747,7 @@ spec:
                       items:
                         properties:
                           destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of
+                            description: IPv4 or IPv6 ip addresses of 
                               destination with optional subnet.
                             items:
                               type: string
@@ -15759,7 +15759,7 @@ spec:
                               type: string
                             type: array
                           port:
-                            description: Specifies the port on the host that is
+                            description: Specifies the port on the host that is 
                               being addressed.
                             maximum: 4294967295
                             minimum: 0
@@ -15767,13 +15767,13 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to workloads with the
+                            description: One or more labels that constrain the 
+                              applicability of a rule to workloads with the 
                               given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                           sourceSubnet:
@@ -15781,17 +15781,17 @@ spec:
                         type: object
                       type: array
                     route:
-                      description: The destination to which the connection
+                      description: The destination to which the connection 
                         should be forwarded to.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -15804,15 +15804,15 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -15823,7 +15823,7 @@ spec:
                   type: object
                 type: array
               tls:
-                description: An ordered list of route rule for non-terminated
+                description: An ordered list of route rule for non-terminated 
                   TLS & HTTPS traffic.
                 items:
                   properties:
@@ -15833,7 +15833,7 @@ spec:
                       items:
                         properties:
                           destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of
+                            description: IPv4 or IPv6 ip addresses of 
                               destination with optional subnet.
                             items:
                               type: string
@@ -15845,13 +15845,13 @@ spec:
                               type: string
                             type: array
                           port:
-                            description: Specifies the port on the host that is
+                            description: Specifies the port on the host that is 
                               being addressed.
                             maximum: 4294967295
                             minimum: 0
                             type: integer
                           sniHosts:
-                            description: SNI (server name indicator) to match
+                            description: SNI (server name indicator) to match 
                               on.
                             items:
                               type: string
@@ -15859,13 +15859,13 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to workloads with the
+                            description: One or more labels that constrain the 
+                              applicability of a rule to workloads with the 
                               given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                         required:
@@ -15873,17 +15873,17 @@ spec:
                         type: object
                       type: array
                     route:
-                      description: The destination to which the connection
+                      description: The destination to which the connection 
                         should be forwarded to.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -15896,15 +15896,15 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -15933,18 +15933,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -15983,12 +15983,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -16002,7 +16002,7 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: The names of gateways and sidecars that should apply these
+    - description: The names of gateways and sidecars that should apply these 
         routes
       jsonPath: .spec.gateways
       name: Gateways
@@ -16028,19 +16028,19 @@ spec:
               etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
             properties:
               exportTo:
-                description: A list of namespaces to which this virtual service
+                description: A list of namespaces to which this virtual service 
                   is exported.
                 items:
                   type: string
                 type: array
               gateways:
-                description: The names of gateways and sidecars that should
+                description: The names of gateways and sidecars that should 
                   apply these routes.
                 items:
                   type: string
                 type: array
               hosts:
-                description: The destination hosts to which traffic is being
+                description: The destination hosts to which traffic is being 
                   sent.
                 items:
                   type: string
@@ -16053,19 +16053,19 @@ spec:
                       description: Cross-Origin Resource Sharing policy (CORS).
                       properties:
                         allowCredentials:
-                          description: Indicates whether the caller is allowed
+                          description: Indicates whether the caller is allowed 
                             to send the actual request (not the preflight) using
                             credentials.
                           nullable: true
                           type: boolean
                         allowHeaders:
-                          description: List of HTTP headers that can be used
+                          description: List of HTTP headers that can be used 
                             when requesting the resource.
                           items:
                             type: string
                           type: array
                         allowMethods:
-                          description: List of HTTP methods allowed to access
+                          description: List of HTTP methods allowed to access 
                             the resource.
                           items:
                             type: string
@@ -16075,7 +16075,7 @@ spec:
                             type: string
                           type: array
                         allowOrigins:
-                          description: String patterns that match allowed
+                          description: String patterns that match allowed 
                             origins.
                           items:
                             oneOf:
@@ -16104,13 +16104,13 @@ spec:
                             type: object
                           type: array
                         exposeHeaders:
-                          description: A list of HTTP headers that the browsers
+                          description: A list of HTTP headers that the browsers 
                             are allowed to access.
                           items:
                             type: string
                           type: array
                         maxAge:
-                          description: Specifies how long the results of a
+                          description: Specifies how long the results of a 
                             preflight request can be cached.
                           type: string
                           x-kubernetes-validations:
@@ -16128,25 +16128,25 @@ spec:
                           type: string
                       type: object
                     delegate:
-                      description: Delegate is used to specify the particular
-                        VirtualService which can be used to define delegate
+                      description: Delegate is used to specify the particular 
+                        VirtualService which can be used to define delegate 
                         HTTPRoute.
                       properties:
                         name:
-                          description: Name specifies the name of the delegate
+                          description: Name specifies the name of the delegate 
                             VirtualService.
                           type: string
                         namespace:
-                          description: Namespace specifies the namespace where
+                          description: Namespace specifies the namespace where 
                             the delegate VirtualService resides.
                           type: string
                       type: object
                     directResponse:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       properties:
                         body:
-                          description: Specifies the content of the response
+                          description: Specifies the content of the response 
                             body.
                           oneOf:
                           - not:
@@ -16161,7 +16161,7 @@ spec:
                             - bytes
                           properties:
                             bytes:
-                              description: response body as base64 encoded
+                              description: response body as base64 encoded 
                                 bytes.
                               format: byte
                               type: string
@@ -16169,7 +16169,7 @@ spec:
                               type: string
                           type: object
                         status:
-                          description: Specifies the HTTP response status to be
+                          description: Specifies the HTTP response status to be 
                             returned.
                           maximum: 4294967295
                           minimum: 0
@@ -16178,12 +16178,12 @@ spec:
                       - status
                       type: object
                     fault:
-                      description: Fault injection policy to apply on HTTP
+                      description: Fault injection policy to apply on HTTP 
                         traffic at the client side.
                       properties:
                         abort:
-                          description: Abort Http request attempts and return
-                            error codes back to downstream service, giving the
+                          description: Abort Http request attempts and return 
+                            error codes back to downstream service, giving the 
                             impression that the upstream service is faulty.
                           oneOf:
                           - not:
@@ -16202,18 +16202,18 @@ spec:
                             - http2Error
                           properties:
                             grpcStatus:
-                              description: GRPC status code to use to abort the
+                              description: GRPC status code to use to abort the 
                                 request.
                               type: string
                             http2Error:
                               type: string
                             httpStatus:
-                              description: HTTP status code to use to abort the
+                              description: HTTP status code to use to abort the 
                                 Http request.
                               format: int32
                               type: integer
                             percentage:
-                              description: Percentage of requests to be aborted
+                              description: Percentage of requests to be aborted 
                                 with the error code provided.
                               properties:
                                 value:
@@ -16222,8 +16222,8 @@ spec:
                               type: object
                           type: object
                         delay:
-                          description: Delay requests before forwarding,
-                            emulating various failures such as network issues,
+                          description: Delay requests before forwarding, 
+                            emulating various failures such as network issues, 
                             overloaded upstream service, etc.
                           oneOf:
                           - not:
@@ -16240,24 +16240,24 @@ spec:
                             exponentialDelay:
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             fixedDelay:
-                              description: Add a fixed delay before forwarding
+                              description: Add a fixed delay before forwarding 
                                 the request.
                               type: string
                               x-kubernetes-validations:
-                              - message: must be a valid duration greater than
+                              - message: must be a valid duration greater than 
                                   1ms
                                 rule: duration(self) >= duration('1ms')
                             percent:
-                              description: Percentage of requests on which the
+                              description: Percentage of requests on which the 
                                 delay will be injected (0-100).
                               format: int32
                               type: integer
                             percentage:
-                              description: Percentage of requests on which the
+                              description: Percentage of requests on which the 
                                 delay will be injected.
                               properties:
                                 value:
@@ -16365,11 +16365,11 @@ spec:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                                   type: string
                               type: object
-                            description: The header keys must be lowercase and
+                            description: The header keys must be lowercase and 
                               use hyphen as the separator, e.g.
                             type: object
                           ignoreUriCase:
-                            description: Flag to specify whether the URI
+                            description: Flag to specify whether the URI 
                               matching should be case-insensitive.
                             type: boolean
                           method:
@@ -16470,17 +16470,17 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to source (client)
+                            description: One or more labels that constrain the 
+                              applicability of a rule to source (client) 
                               workloads with the given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                           statPrefix:
-                            description: The human readable prefix to use when
+                            description: The human readable prefix to use when 
                               emitting statistics for this route.
                             type: string
                           uri:
@@ -16538,22 +16538,22 @@ spec:
                                   description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                                   type: string
                               type: object
-                            description: withoutHeader has the same syntax with
+                            description: withoutHeader has the same syntax with 
                               the header, but has opposite meaning.
                             type: object
                         type: object
                       type: array
                     mirror:
-                      description: Mirror HTTP traffic to a another destination
-                        in addition to forwarding the requests to the intended
+                      description: Mirror HTTP traffic to a another destination 
+                        in addition to forwarding the requests to the intended 
                         destination.
                       properties:
                         host:
-                          description: The name of a service from the service
+                          description: The name of a service from the service 
                             registry.
                           type: string
                         port:
-                          description: Specifies the port on the host that is
+                          description: Specifies the port on the host that is 
                             being addressed.
                           properties:
                             number:
@@ -16578,7 +16578,7 @@ spec:
                       nullable: true
                       type: integer
                     mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by
+                      description: Percentage of the traffic to be mirrored by 
                         the `mirror` field.
                       properties:
                         value:
@@ -16586,7 +16586,7 @@ spec:
                           type: number
                       type: object
                     mirrors:
-                      description: Specifies the destinations to mirror HTTP
+                      description: Specifies the destinations to mirror HTTP 
                         traffic in addition to the original destination.
                       items:
                         properties:
@@ -16595,7 +16595,7 @@ spec:
                               mirror operation.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -16608,14 +16608,14 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           percentage:
-                            description: Percentage of the traffic to be
+                            description: Percentage of the traffic to be 
                               mirrored by the `destination` field.
                             properties:
                               value:
@@ -16627,11 +16627,11 @@ spec:
                         type: object
                       type: array
                     name:
-                      description: The name assigned to the route for debugging
+                      description: The name assigned to the route for debugging 
                         purposes.
                       type: string
                     redirect:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       oneOf:
                       - not:
@@ -16646,7 +16646,7 @@ spec:
                         - derivePort
                       properties:
                         authority:
-                          description: On a redirect, overwrite the
+                          description: On a redirect, overwrite the 
                             Authority/Host portion of the URL with this value.
                           type: string
                         derivePort:
@@ -16665,13 +16665,13 @@ spec:
                           minimum: 0
                           type: integer
                         redirectCode:
-                          description: On a redirect, Specifies the HTTP status
+                          description: On a redirect, Specifies the HTTP status 
                             code to use in the redirect response.
                           maximum: 4294967295
                           minimum: 0
                           type: integer
                         scheme:
-                          description: On a redirect, overwrite the scheme
+                          description: On a redirect, overwrite the scheme 
                             portion of the URL with this value.
                           type: string
                         uri:
@@ -16683,35 +16683,35 @@ spec:
                       description: Retry policy for HTTP requests.
                       properties:
                         attempts:
-                          description: Number of retries to be allowed for a
+                          description: Number of retries to be allowed for a 
                             given request.
                           format: int32
                           type: integer
                         backoff:
-                          description: Specifies the minimum duration between
+                          description: Specifies the minimum duration between 
                             retry attempts.
                           type: string
                           x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
                         perTryTimeout:
-                          description: Timeout per attempt for a given request,
+                          description: Timeout per attempt for a given request, 
                             including the initial call and any retries.
                           type: string
                           x-kubernetes-validations:
                           - message: must be a valid duration greater than 1ms
                             rule: duration(self) >= duration('1ms')
                         retryIgnorePreviousHosts:
-                          description: Flag to specify whether the retries
+                          description: Flag to specify whether the retries 
                             should ignore previously tried hosts during retry.
                           nullable: true
                           type: boolean
                         retryOn:
-                          description: Specifies the conditions under which
+                          description: Specifies the conditions under which 
                             retry takes place.
                           type: string
                         retryRemoteLocalities:
-                          description: Flag to specify whether the retries
+                          description: Flag to specify whether the retries 
                             should retry to other localities.
                           nullable: true
                           type: boolean
@@ -16720,38 +16720,38 @@ spec:
                       description: Rewrite HTTP URIs and Authority headers.
                       properties:
                         authority:
-                          description: rewrite the Authority/Host header with
+                          description: rewrite the Authority/Host header with 
                             this value.
                           type: string
                         uri:
-                          description: rewrite the path (or the prefix) portion
+                          description: rewrite the path (or the prefix) portion 
                             of the URI with this value.
                           type: string
                         uriRegexRewrite:
-                          description: rewrite the path portion of the URI with
+                          description: rewrite the path portion of the URI with 
                             the specified regex.
                           properties:
                             match:
                               description: '[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).'
                               type: string
                             rewrite:
-                              description: The string that should replace into
+                              description: The string that should replace into 
                                 matching portions of original URI.
                               type: string
                           type: object
                       type: object
                     route:
-                      description: A HTTP rule can either return a
+                      description: A HTTP rule can either return a 
                         direct_response, redirect or forward (default) traffic.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -16764,7 +16764,7 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
@@ -16804,8 +16804,8 @@ spec:
                                 type: object
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -16814,7 +16814,7 @@ spec:
                         type: object
                       type: array
                     timeout:
-                      description: Timeout for HTTP requests, default is
+                      description: Timeout for HTTP requests, default is 
                         disabled.
                       type: string
                       x-kubernetes-validations:
@@ -16823,7 +16823,7 @@ spec:
                   type: object
                 type: array
               tcp:
-                description: An ordered list of route rules for opaque TCP
+                description: An ordered list of route rules for opaque TCP 
                   traffic.
                 items:
                   properties:
@@ -16833,7 +16833,7 @@ spec:
                       items:
                         properties:
                           destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of
+                            description: IPv4 or IPv6 ip addresses of 
                               destination with optional subnet.
                             items:
                               type: string
@@ -16845,7 +16845,7 @@ spec:
                               type: string
                             type: array
                           port:
-                            description: Specifies the port on the host that is
+                            description: Specifies the port on the host that is 
                               being addressed.
                             maximum: 4294967295
                             minimum: 0
@@ -16853,13 +16853,13 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to workloads with the
+                            description: One or more labels that constrain the 
+                              applicability of a rule to workloads with the 
                               given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                           sourceSubnet:
@@ -16867,17 +16867,17 @@ spec:
                         type: object
                       type: array
                     route:
-                      description: The destination to which the connection
+                      description: The destination to which the connection 
                         should be forwarded to.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -16890,15 +16890,15 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -16909,7 +16909,7 @@ spec:
                   type: object
                 type: array
               tls:
-                description: An ordered list of route rule for non-terminated
+                description: An ordered list of route rule for non-terminated 
                   TLS & HTTPS traffic.
                 items:
                   properties:
@@ -16919,7 +16919,7 @@ spec:
                       items:
                         properties:
                           destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of
+                            description: IPv4 or IPv6 ip addresses of 
                               destination with optional subnet.
                             items:
                               type: string
@@ -16931,13 +16931,13 @@ spec:
                               type: string
                             type: array
                           port:
-                            description: Specifies the port on the host that is
+                            description: Specifies the port on the host that is 
                               being addressed.
                             maximum: 4294967295
                             minimum: 0
                             type: integer
                           sniHosts:
-                            description: SNI (server name indicator) to match
+                            description: SNI (server name indicator) to match 
                               on.
                             items:
                               type: string
@@ -16945,13 +16945,13 @@ spec:
                           sourceLabels:
                             additionalProperties:
                               type: string
-                            description: One or more labels that constrain the
-                              applicability of a rule to workloads with the
+                            description: One or more labels that constrain the 
+                              applicability of a rule to workloads with the 
                               given labels.
                             type: object
                           sourceNamespace:
-                            description: Source namespace constraining the
-                              applicability of a rule to workloads in that
+                            description: Source namespace constraining the 
+                              applicability of a rule to workloads in that 
                               namespace.
                             type: string
                         required:
@@ -16959,17 +16959,17 @@ spec:
                         type: object
                       type: array
                     route:
-                      description: The destination to which the connection
+                      description: The destination to which the connection 
                         should be forwarded to.
                       items:
                         properties:
                           destination:
-                            description: Destination uniquely identifies the
-                              instances of a service to which the
+                            description: Destination uniquely identifies the 
+                              instances of a service to which the 
                               request/connection should be forwarded to.
                             properties:
                               host:
-                                description: The name of a service from the
+                                description: The name of a service from the 
                                   service registry.
                                 type: string
                               port:
@@ -16982,15 +16982,15 @@ spec:
                                     type: integer
                                 type: object
                               subset:
-                                description: The name of a subset within the
+                                description: The name of a subset within the 
                                   service.
                                 type: string
                             required:
                             - host
                             type: object
                           weight:
-                            description: Weight specifies the relative
-                              proportion of traffic to be forwarded to the
+                            description: Weight specifies the relative 
+                              proportion of traffic to be forwarded to the 
                               destination.
                             format: int32
                             type: integer
@@ -17019,18 +17019,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -17069,12 +17069,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -17156,7 +17156,7 @@ spec:
                 minLength: 1
                 type: string
               match:
-                description: Specifies the criteria to determine which traffic
+                description: Specifies the criteria to determine which traffic 
                   is passed to WasmPlugin.
                 items:
                   properties:
@@ -17172,7 +17172,7 @@ spec:
                       - CLIENT_AND_SERVER
                       type: string
                     ports:
-                      description: Criteria for selecting traffic by their
+                      description: Criteria for selecting traffic by their 
                         destination port.
                       items:
                         properties:
@@ -17201,24 +17201,24 @@ spec:
                 - STATS
                 type: string
               pluginConfig:
-                description: The configuration that will be passed on to the
+                description: The configuration that will be passed on to the 
                   plugin.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               pluginName:
-                description: The plugin name to be used in the Envoy
+                description: The plugin name to be used in the Envoy 
                   configuration (used to be called `rootID`).
                 maxLength: 256
                 minLength: 1
                 type: string
               priority:
-                description: Determines ordering of `WasmPlugins` in the same
+                description: Determines ordering of `WasmPlugins` in the same 
                   `phase`.
                 format: int32
                 nullable: true
                 type: integer
               selector:
-                description: Criteria used to select the specific set of
+                description: Criteria used to select the specific set of 
                   pods/VMs on which this plugin configuration should be applied.
                 properties:
                   matchLabels:
@@ -17239,7 +17239,7 @@ spec:
                       rule: self.all(key, key.size() != 0)
                 type: object
               sha256:
-                description: SHA256 checksum that will be used to verify Wasm
+                description: SHA256 checksum that will be used to verify Wasm 
                   module or OCI container.
                 pattern: (^$|^[a-f0-9]{64}$)
                 type: string
@@ -17248,7 +17248,7 @@ spec:
                   group:
                     description: group is the group of the target resource.
                     maxLength: 253
-                    pattern:
+                    pattern: 
                       ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
@@ -17266,7 +17266,7 @@ spec:
                     description: namespace is the namespace of the referent.
                     type: string
                     x-kubernetes-validations:
-                    - message: cross namespace referencing is not currently
+                    - message: cross namespace referencing is not currently 
                         supported
                       rule: self.size() == 0
                 required:
@@ -17280,7 +17280,7 @@ spec:
                     group:
                       description: group is the group of the target resource.
                       maxLength: 253
-                      pattern:
+                      pattern: 
                         ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
@@ -17298,7 +17298,7 @@ spec:
                       description: namespace is the namespace of the referent.
                       type: string
                       x-kubernetes-validations:
-                      - message: cross namespace referencing is not currently
+                      - message: cross namespace referencing is not currently 
                           supported
                         rule: self.size() == 0
                   required:
@@ -17332,7 +17332,7 @@ spec:
                 description: Configuration for a Wasm VM.
                 properties:
                   env:
-                    description: Specifies environment variables to be injected
+                    description: Specifies environment variables to be injected 
                       to this VM.
                     items:
                       properties:
@@ -17390,18 +17390,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -17440,12 +17440,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -17510,7 +17510,7 @@ spec:
               more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
             properties:
               address:
-                description: Address associated with the network endpoint
+                description: Address associated with the network endpoint 
                   without the port.
                 maxLength: 256
                 type: string
@@ -17531,7 +17531,7 @@ spec:
                 maxLength: 2048
                 type: string
               network:
-                description: Network enables Istio to group endpoints resident
+                description: Network enables Istio to group endpoints resident 
                   in the same L3 domain/network.
                 maxLength: 2048
                 type: string
@@ -17548,7 +17548,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: port name must be valid
-                  rule: self.all(key, size(key) < 63 &&
+                  rule: self.all(key, size(key) < 63 && 
                     key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
               serviceAccount:
                 description: The service account associated with the workload if
@@ -17556,7 +17556,7 @@ spec:
                 maxLength: 253
                 type: string
               weight:
-                description: The load balancing weight associated with the
+                description: The load balancing weight associated with the 
                   endpoint.
                 maximum: 4294967295
                 minimum: 0
@@ -17584,18 +17584,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -17634,12 +17634,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -17676,7 +17676,7 @@ spec:
               more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
             properties:
               address:
-                description: Address associated with the network endpoint
+                description: Address associated with the network endpoint 
                   without the port.
                 maxLength: 256
                 type: string
@@ -17697,7 +17697,7 @@ spec:
                 maxLength: 2048
                 type: string
               network:
-                description: Network enables Istio to group endpoints resident
+                description: Network enables Istio to group endpoints resident 
                   in the same L3 domain/network.
                 maxLength: 2048
                 type: string
@@ -17714,7 +17714,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: port name must be valid
-                  rule: self.all(key, size(key) < 63 &&
+                  rule: self.all(key, size(key) < 63 && 
                     key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
               serviceAccount:
                 description: The service account associated with the workload if
@@ -17722,7 +17722,7 @@ spec:
                 maxLength: 253
                 type: string
               weight:
-                description: The load balancing weight associated with the
+                description: The load balancing weight associated with the 
                   endpoint.
                 maximum: 4294967295
                 minimum: 0
@@ -17750,18 +17750,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -17800,12 +17800,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -17842,7 +17842,7 @@ spec:
               more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
             properties:
               address:
-                description: Address associated with the network endpoint
+                description: Address associated with the network endpoint 
                   without the port.
                 maxLength: 256
                 type: string
@@ -17863,7 +17863,7 @@ spec:
                 maxLength: 2048
                 type: string
               network:
-                description: Network enables Istio to group endpoints resident
+                description: Network enables Istio to group endpoints resident 
                   in the same L3 domain/network.
                 maxLength: 2048
                 type: string
@@ -17880,7 +17880,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: port name must be valid
-                  rule: self.all(key, size(key) < 63 &&
+                  rule: self.all(key, size(key) < 63 && 
                     key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
               serviceAccount:
                 description: The service account associated with the workload if
@@ -17888,7 +17888,7 @@ spec:
                 maxLength: 253
                 type: string
               weight:
-                description: The load balancing weight associated with the
+                description: The load balancing weight associated with the 
                   endpoint.
                 maximum: 4294967295
                 minimum: 0
@@ -17916,18 +17916,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -17966,12 +17966,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -18032,7 +18032,7 @@ spec:
               at: https://istio.io/docs/reference/config/networking/workload-group.html'
             properties:
               metadata:
-                description: Metadata that will be used for all corresponding
+                description: Metadata that will be used for all corresponding 
                   `WorkloadEntries`.
                 properties:
                   annotations:
@@ -18083,7 +18083,7 @@ spec:
                     - command
                     type: object
                   failureThreshold:
-                    description: Minimum consecutive failures for the probe to
+                    description: Minimum consecutive failures for the probe to 
                       be considered failed after having succeeded.
                     format: int32
                     minimum: 0
@@ -18108,11 +18108,11 @@ spec:
                       status/able to connect determines health.'
                     properties:
                       host:
-                        description: Host name to connect to, defaults to the
+                        description: Host name to connect to, defaults to the 
                           pod IP.
                         type: string
                       httpHeaders:
-                        description: Headers the proxy will pass on to make the
+                        description: Headers the proxy will pass on to make the 
                           request.
                         items:
                           properties:
@@ -18143,7 +18143,7 @@ spec:
                     - port
                     type: object
                   initialDelaySeconds:
-                    description: Number of seconds after the container has
+                    description: Number of seconds after the container has 
                       started before readiness probes are initiated.
                     format: int32
                     minimum: 0
@@ -18154,7 +18154,7 @@ spec:
                     minimum: 0
                     type: integer
                   successThreshold:
-                    description: Minimum consecutive successes for the probe to
+                    description: Minimum consecutive successes for the probe to 
                       be considered successful after having failed.
                     format: int32
                     minimum: 0
@@ -18176,18 +18176,18 @@ spec:
                     - port
                     type: object
                   timeoutSeconds:
-                    description: Number of seconds after which the probe times
+                    description: Number of seconds after which the probe times 
                       out.
                     format: int32
                     minimum: 0
                     type: integer
                 type: object
               template:
-                description: Template to be used for the generation of
+                description: Template to be used for the generation of 
                   `WorkloadEntry` resources that belong to this `WorkloadGroup`.
                 properties:
                   address:
-                    description: Address associated with the network endpoint
+                    description: Address associated with the network endpoint 
                       without the port.
                     maxLength: 256
                     type: string
@@ -18200,7 +18200,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: One or more labels associated with the
+                    description: One or more labels associated with the 
                       endpoint.
                     maxProperties: 256
                     type: object
@@ -18209,7 +18209,7 @@ spec:
                     maxLength: 2048
                     type: string
                   network:
-                    description: Network enables Istio to group endpoints
+                    description: Network enables Istio to group endpoints 
                       resident in the same L3 domain/network.
                     maxLength: 2048
                     type: string
@@ -18226,15 +18226,15 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: port name must be valid
-                      rule: self.all(key, size(key) < 63 &&
+                      rule: self.all(key, size(key) < 63 && 
                         key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
                   serviceAccount:
-                    description: The service account associated with the
+                    description: The service account associated with the 
                       workload if a sidecar is present in the workload.
                     maxLength: 253
                     type: string
                   weight:
-                    description: The load balancing weight associated with the
+                    description: The load balancing weight associated with the 
                       endpoint.
                     maximum: 4294967295
                     minimum: 0
@@ -18263,18 +18263,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -18313,12 +18313,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -18351,7 +18351,7 @@ spec:
               at: https://istio.io/docs/reference/config/networking/workload-group.html'
             properties:
               metadata:
-                description: Metadata that will be used for all corresponding
+                description: Metadata that will be used for all corresponding 
                   `WorkloadEntries`.
                 properties:
                   annotations:
@@ -18402,7 +18402,7 @@ spec:
                     - command
                     type: object
                   failureThreshold:
-                    description: Minimum consecutive failures for the probe to
+                    description: Minimum consecutive failures for the probe to 
                       be considered failed after having succeeded.
                     format: int32
                     minimum: 0
@@ -18427,11 +18427,11 @@ spec:
                       status/able to connect determines health.'
                     properties:
                       host:
-                        description: Host name to connect to, defaults to the
+                        description: Host name to connect to, defaults to the 
                           pod IP.
                         type: string
                       httpHeaders:
-                        description: Headers the proxy will pass on to make the
+                        description: Headers the proxy will pass on to make the 
                           request.
                         items:
                           properties:
@@ -18462,7 +18462,7 @@ spec:
                     - port
                     type: object
                   initialDelaySeconds:
-                    description: Number of seconds after the container has
+                    description: Number of seconds after the container has 
                       started before readiness probes are initiated.
                     format: int32
                     minimum: 0
@@ -18473,7 +18473,7 @@ spec:
                     minimum: 0
                     type: integer
                   successThreshold:
-                    description: Minimum consecutive successes for the probe to
+                    description: Minimum consecutive successes for the probe to 
                       be considered successful after having failed.
                     format: int32
                     minimum: 0
@@ -18495,18 +18495,18 @@ spec:
                     - port
                     type: object
                   timeoutSeconds:
-                    description: Number of seconds after which the probe times
+                    description: Number of seconds after which the probe times 
                       out.
                     format: int32
                     minimum: 0
                     type: integer
                 type: object
               template:
-                description: Template to be used for the generation of
+                description: Template to be used for the generation of 
                   `WorkloadEntry` resources that belong to this `WorkloadGroup`.
                 properties:
                   address:
-                    description: Address associated with the network endpoint
+                    description: Address associated with the network endpoint 
                       without the port.
                     maxLength: 256
                     type: string
@@ -18519,7 +18519,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: One or more labels associated with the
+                    description: One or more labels associated with the 
                       endpoint.
                     maxProperties: 256
                     type: object
@@ -18528,7 +18528,7 @@ spec:
                     maxLength: 2048
                     type: string
                   network:
-                    description: Network enables Istio to group endpoints
+                    description: Network enables Istio to group endpoints 
                       resident in the same L3 domain/network.
                     maxLength: 2048
                     type: string
@@ -18545,15 +18545,15 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: port name must be valid
-                      rule: self.all(key, size(key) < 63 &&
+                      rule: self.all(key, size(key) < 63 && 
                         key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
                   serviceAccount:
-                    description: The service account associated with the
+                    description: The service account associated with the 
                       workload if a sidecar is present in the workload.
                     maxLength: 253
                     type: string
                   weight:
-                    description: The load balancing weight associated with the
+                    description: The load balancing weight associated with the 
                       endpoint.
                     maximum: 4294967295
                     minimum: 0
@@ -18582,18 +18582,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -18632,12 +18632,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -18670,7 +18670,7 @@ spec:
               at: https://istio.io/docs/reference/config/networking/workload-group.html'
             properties:
               metadata:
-                description: Metadata that will be used for all corresponding
+                description: Metadata that will be used for all corresponding 
                   `WorkloadEntries`.
                 properties:
                   annotations:
@@ -18721,7 +18721,7 @@ spec:
                     - command
                     type: object
                   failureThreshold:
-                    description: Minimum consecutive failures for the probe to
+                    description: Minimum consecutive failures for the probe to 
                       be considered failed after having succeeded.
                     format: int32
                     minimum: 0
@@ -18746,11 +18746,11 @@ spec:
                       status/able to connect determines health.'
                     properties:
                       host:
-                        description: Host name to connect to, defaults to the
+                        description: Host name to connect to, defaults to the 
                           pod IP.
                         type: string
                       httpHeaders:
-                        description: Headers the proxy will pass on to make the
+                        description: Headers the proxy will pass on to make the 
                           request.
                         items:
                           properties:
@@ -18781,7 +18781,7 @@ spec:
                     - port
                     type: object
                   initialDelaySeconds:
-                    description: Number of seconds after the container has
+                    description: Number of seconds after the container has 
                       started before readiness probes are initiated.
                     format: int32
                     minimum: 0
@@ -18792,7 +18792,7 @@ spec:
                     minimum: 0
                     type: integer
                   successThreshold:
-                    description: Minimum consecutive successes for the probe to
+                    description: Minimum consecutive successes for the probe to 
                       be considered successful after having failed.
                     format: int32
                     minimum: 0
@@ -18814,18 +18814,18 @@ spec:
                     - port
                     type: object
                   timeoutSeconds:
-                    description: Number of seconds after which the probe times
+                    description: Number of seconds after which the probe times 
                       out.
                     format: int32
                     minimum: 0
                     type: integer
                 type: object
               template:
-                description: Template to be used for the generation of
+                description: Template to be used for the generation of 
                   `WorkloadEntry` resources that belong to this `WorkloadGroup`.
                 properties:
                   address:
-                    description: Address associated with the network endpoint
+                    description: Address associated with the network endpoint 
                       without the port.
                     maxLength: 256
                     type: string
@@ -18838,7 +18838,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: One or more labels associated with the
+                    description: One or more labels associated with the 
                       endpoint.
                     maxProperties: 256
                     type: object
@@ -18847,7 +18847,7 @@ spec:
                     maxLength: 2048
                     type: string
                   network:
-                    description: Network enables Istio to group endpoints
+                    description: Network enables Istio to group endpoints 
                       resident in the same L3 domain/network.
                     maxLength: 2048
                     type: string
@@ -18864,15 +18864,15 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: port name must be valid
-                      rule: self.all(key, size(key) < 63 &&
+                      rule: self.all(key, size(key) < 63 && 
                         key.matches("^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$"))
                   serviceAccount:
-                    description: The service account associated with the
+                    description: The service account associated with the 
                       workload if a sidecar is present in the workload.
                     maxLength: 253
                     type: string
                   weight:
-                    description: The load balancing weight associated with the
+                    description: The load balancing weight associated with the 
                       endpoint.
                     maximum: 4294967295
                     minimum: 0
@@ -18901,18 +18901,18 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details
+                      description: Human-readable message indicating details 
                         about last transition.
                       type: string
                     observedGeneration:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Resource Generation to which the Condition
+                      description: Resource Generation to which the Condition 
                         refers.
                       x-kubernetes-int-or-string: true
                     reason:
-                      description: Unique, one-word, CamelCase reason for the
+                      description: Unique, one-word, CamelCase reason for the 
                         condition's last transition.
                       type: string
                     status:
@@ -18951,12 +18951,12 @@ spec:
                     type:
                       properties:
                         code:
-                          description: A 7 character code matching
-                            `^IST[0-9]{4}$` intended to uniquely identify the
+                          description: A 7 character code matching 
+                            `^IST[0-9]{4}$` intended to uniquely identify the 
                             message type.
                           type: string
                         name:
-                          description: A human-readable name for the message
+                          description: A human-readable name for the message 
                             type.
                           type: string
                       type: object
@@ -18971,3 +18971,4 @@ spec:
     storage: false
     subresources:
       status: {}
+

--- a/common/istio/istio-install/base/install.yaml
+++ b/common/istio/istio-install/base/install.yaml
@@ -3605,8 +3605,8 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    kubernetes.io/description: This ConfigMap contains the Helm values used
-      during chart rendering. This ConfigMap is rendered for debugging purposes
+    kubernetes.io/description: This ConfigMap contains the Helm values used 
+      during chart rendering. This ConfigMap is rendered for debugging purposes 
       and external tooling; modifying these values has no effect.
   labels:
     app.kubernetes.io/instance: istio
@@ -4046,7 +4046,7 @@ spec:
         - name: ISTIO_META_WORKLOAD_NAME
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
-          value:
+          value: 
             kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
         - name: ISTIO_META_MESH_ID
           value: cluster.local


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

Found by running `synchronize-istio-manifests.sh` and `scripts/synchronize-spark-operator-manifests.sh` that there are differences without any upstream changes.


## 📦 Dependencies

_None_

## 🐛 Related Issues

_None_

## ✅ Contributor Checklist

- [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
