### PR TITLE
ci: Add GHA to check for idempotence of PRs that touch upstream folders

### DIFF
--- a/.github/workflows/upstream-synchronization-idempotence-test.yaml
+++ b/.github/workflows/upstream-synchronization-idempotence-test.yaml
@@ -1,0 +1,36 @@
+name: Check if the upstream synchronization is idempotent
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  upstream_synchronization_idempotence_test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0
+
+    - name: Setup python 3.13
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.13"
+
+    - name: Run upstream synchronization scripts for changed files
+      run: |
+        mapfile -t changed_files < <(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+        tests/resynchronize-upstream-changes.py "${changed_files[@]}"
+
+    - name: Check that the upstream synchronization is idempotent
+      run: |
+        clean=$(git status --porcelain)
+        if [[ -z "$clean" ]]; then
+            echo "No changes detected, upstream synchronization is idempotent"
+        else
+            echo "Upstream synchronization introduced changes, sync is not idempotent:"
+            git diff
+            exit 1
+        fi

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
+
 # Common functions for Kubeflow manifest synchronization scripts
+
 setup_error_handling() {
   set -euxo pipefail
   IFS=$'\n\t'
 }
+
 # Check if the git repository has uncommitted changes
 check_uncommitted_changes() {
   if [ -n "$(git status --porcelain)" ]; then
     echo "WARNING: You have uncommitted changes"
   fi
 }
+
 # Create a new git branch if it doesn't exist
 create_branch() {
+  if [[ "${KUBEFLOW_SYNCHRONIZE_NO_COMMIT:-}" == "true" ]]; then
+    return
+  fi
   local branch="$1"
   check_uncommitted_changes
   if ! git show-ref --verify --quiet refs/heads/$branch; then
@@ -20,6 +27,7 @@ create_branch() {
     echo "Branch $branch already exists."
   fi
 }
+
 clone_and_checkout() {
   local source_directory="$1"
   local repository_url="$2"
@@ -40,6 +48,7 @@ clone_and_checkout() {
   fi
   check_uncommitted_changes
 }
+
 # Copy manifests from source to destination
 copy_manifests() {
   local source="$1"
@@ -49,6 +58,7 @@ copy_manifests() {
   fi
   cp "$source" "$destination" -r
 }
+
 # Update README with new commit reference
 update_readme() {
   local manifests_directory="$1"
@@ -60,8 +70,12 @@ update_readme() {
     sed -i "s|$source_text|$destination_text|g" "${manifests_directory}/README.md" # GNU sed of Linux
   fi
 }
+
 # Commit changes to git repository
 commit_changes() {
+  if [[ "${KUBEFLOW_SYNCHRONIZE_NO_COMMIT:-}" == "true" ]]; then
+    return
+  fi
   local manifests_directory="$1"
   local commit_message="$2"
   local paths_to_add=("${@:3}")
@@ -70,4 +84,4 @@ commit_changes() {
     git add "$path"
   done
   git commit -s -m "$commit_message"
-} 
+}

--- a/tests/resynchronize-upstream-changes.py
+++ b/tests/resynchronize-upstream-changes.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+
+from pathlib import Path
+
+path_to_synchronization_script = {
+    "applications/dashboard/upstream": "scripts/synchronize-dashboard-manifests.sh",
+    "applications/hub/upstream": "scripts/synchronize-hub-manifests.sh",
+    "applications/katib/upstream": "scripts/synchronize-katib-manifests.sh",
+    "applications/kserve/kserve/upstream": "scripts/synchronize-kserve-kserve-manifests.sh",
+    "applications/kserve/kserve-ui/upstream": "scripts/synchronize-kserve-ui-manifests.sh",
+    "applications/notebooks-v1/upstream": "scripts/synchronize-notebooks-v1-manifests.sh",
+    "applications/pipeline/upstream": "scripts/synchronize-pipelines-manifests.sh",
+    "applications/spark/spark-operator": "scripts/synchronize-spark-operator-manifests.sh",
+    "applications/trainer/upstream": "scripts/synchronize-trainer-manifests.sh",
+    "applications/training-operator/upstream": "scripts/synchronize-training-operator-manifests.sh",
+    "applications/workspaces/upstream": "scripts/synchronize-kubeflow-workspaces-manifests.sh",
+    "common/cert-manager": "scripts/synchronize-cert-manager-manifests.sh",
+    "common/dex": "scripts/synchronize-dex-manifests.sh",
+    "common/istio": "scripts/synchronize-istio-manifests.sh",
+    "common/knative": "scripts/synchronize-knative-manifests.sh",
+    "common/oauth2-proxy": "scripts/synchronize-oauth2-proxy-manifests.sh",
+}
+
+# convert the strings above into actual path objects for easier handling later
+path_to_synchronization_script = {
+    Path(k): Path(v) for k, v in path_to_synchronization_script.items()
+}
+
+
+def find_upstream_scripts(changed_files: list[Path]) -> set[Path]:
+    upstream_scripts = set()
+    for changed in changed_files:
+        for upstream_path, script in path_to_synchronization_script.items():
+            if upstream_path in changed.parents or changed == upstream_path:
+                upstream_scripts.add(script)
+    return upstream_scripts
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Find synchronization scripts for changed upstream files."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        metavar="FILE",
+        help="Changed file paths to check against tracked upstream directories.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the scripts that would run without executing them.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all synchronization scripts regardless of changed files.",
+    )
+    args = parser.parse_args()
+
+    if args.all:
+        upstream_scripts = set(path_to_synchronization_script.values())
+    else:
+        upstream_scripts = find_upstream_scripts(args.files)
+    failed = False
+    for script in sorted(upstream_scripts):
+        print(f"Running {script}...")
+        if args.dry_run:
+            print(f"Skipping {script} due to '--dry-run'")
+            continue
+        process = subprocess.Popen(
+            [script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env={"KUBEFLOW_SYNCHRONIZE_NO_COMMIT": "true"},
+            text=True,
+        )
+        output, _ = process.communicate()
+        if process.returncode != 0:
+            print(output, end="")
+            failed = True
+
+    if failed:
+        sys.exit(1)


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

The goal of this change is to:

- Make sure that there are no hidden changes that a contributor has
  smuggled into a sync PR (think about a 100k LoC kserve sync with a
  malicious, 1-character image reference inside of it).
- Ensures that there is no unexpected override of changes in the
  upstream folders that would get lost on next sync.

A test example of this can be found on my hard-fork: https://github.com/christian-heusel/community-distribution-playground/pull/4 / [link to action output](https://github.com/christian-heusel/community-distribution-playground/actions/runs/28411697521/job/84185811560?pr=4#step:5:20)

## 📦 Dependencies

- #3518
- #3517
- #3516

The following other changes also need cleanup, however they first need to be upstreamed after verifying that they are the right thing to do (which is a nice task for a GSoC student maybe?) into the Kubeflow respective projects:

```diff
diff --git a/applications/katib/upstream/components/mysql/mysql.yaml b/applications/katib/upstream/components/mysql/mysql.yaml
index 1dbd3d4e..e948b45d 100644
--- a/applications/katib/upstream/components/mysql/mysql.yaml
+++ b/applications/katib/upstream/components/mysql/mysql.yaml
@@ -24,7 +24,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: katib-mysql
-          image: mysql:8.0
+          image: mysql:8.0.29
           args:
             - --datadir
             - /var/lib/mysql/datadir
@@ -46,19 +46,27 @@ spec:
               command:
                 - "/bin/bash"
                 - "-c"
-                - "mysql -h 127.0.0.1 -D ${MYSQL_DATABASE} -u root -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
+                - "mysql -D ${MYSQL_DATABASE} -u root -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
             initialDelaySeconds: 10
             periodSeconds: 5
             failureThreshold: 10
           livenessProbe:
             exec:
               command:
-              - "/bin/bash"
-              - "-c"
-              - "mysql -h 127.0.0.1 -D ${MYSQL_DATABASE} -u root -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
+                - "/bin/bash"
+                - "-c"
+                - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
             initialDelaySeconds: 10
             periodSeconds: 5
             failureThreshold: 10
+          startupProbe:
+            exec:
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+            periodSeconds: 15
+            failureThreshold: 60
           volumeMounts:
             - name: katib-mysql
               mountPath: /var/lib/mysql
diff --git a/applications/training-operator/upstream/base/deployment.yaml b/applications/training-operator/upstream/base/deployment.yaml
index c58c98fe..db65c19a 100644
--- a/applications/training-operator/upstream/base/deployment.yaml
+++ b/applications/training-operator/upstream/base/deployment.yaml
@@ -13,11 +13,9 @@ spec:
     metadata:
       labels:
         control-plane: kubeflow-training-operator
+      annotations:
         sidecar.istio.io/inject: "false"
     spec:
-      securityContext:
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - command:
             - /manager
@@ -39,11 +37,6 @@ spec:
                   fieldPath: metadata.name
           securityContext:
             allowPrivilegeEscalation: false
-            runAsUser: 1000
-            runAsNonRoot: true
-            capabilities:
-              drop:
-              - ALL
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
```

## 🐛 Related Issues

_None_

## ✅ Contributor Checklist

- [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
