### PR TITLE
assembling release v26.10 team and roadmap

### DIFF
--- a/releases/release-26.10/README.md
+++ b/releases/release-26.10/README.md
@@ -1,0 +1,39 @@
+# Kubeflow AI Reference Platform 26.10
+
+### Links
+
+- [Release Team](release-team.md)
+- [Calendar](https://www.kubeflow.org/docs/about/community/#kubeflow-community-meetings)
+- [Meeting Notes / Recordings](https://docs.google.com/document/d/1OUWifNf7hZ_QH3m1J3zjSUUk11yKUZnvom1BS2KxrUQ)
+- [Project Board (Private)](https://github.com/orgs/kubeflow/projects/84)
+- Contact
+  - [#kubeflow-platform](https://cloud-native.slack.com/archives/C073W572LA2) on slack
+  - [#kubeflow-release-team](https://cloud-native.slack.com/archives/C0ACZPHKR9N) on slack
+  - [@release-team](https://github.com/orgs/kubeflow/teams/release-team) on GitHub
+
+### TL;DR
+
+The 26.10 release cycle is proposed as follows:
+
+| Meeting? | Week | Date | Internal Project Milestones | Industry Events & Conferences |
+| :---: | :--- | :--- | :--- | :--- |
+| **Yes** | Week 0 | 29 Jun | Team assembly / Roadmap discussion | |
+| | Week 1 | 06 Jul | | |
+| **Yes** | Week 2 | 13 Jul | Development starts | |
+| | Week 3 | 20 Jul | | |
+| **Yes** | Week 4 | 27 Jul | | KubeCon Japan |
+| | Week 5 | 03 Aug | | |
+| **Yes** | Week 6 | 10 Aug | | |
+| | Week 7 | 17 Aug | | Kubeflow Virtual Event |
+| **Yes** | Week 8 | 24 Aug | | |
+| | Week 9 | 31 Aug | | |
+| **Yes** | Week 10 | 07 Sep | Feature Freeze, RC1 cut / Testing *(Note: US Labor Day Sept 7)* | KubeCon China |
+| | Week 11 | 14 Sep | | |
+| **Yes** | Week 12 | 21 Sep | Release Decision - RC1 final or cut RC2? | |
+| | Week 13 | 28 Sep | | |
+| **Yes** | Week 14 | 05 Oct | Release Prep; Documentation, Blog Post, Website | Open Source Summit EU |
+| | Week 15 | 12 Oct | | |
+| **Yes** | Week 16 | 19 Oct | | |
+| | Week 17 | 26 Oct | 26.10 release | |
+| **Yes** | Week 18 | 02 Nov | | |
+| | Week 19 | 09 Nov | | KubeCon NA |

--- a/releases/release-26.10/README.md
+++ b/releases/release-26.10/README.md
@@ -1,4 +1,4 @@
-# Kubeflow AI Reference Platform 26.10
+# Kubeflow Community Distribution 26.10
 
 ### Links
 
@@ -7,9 +7,9 @@
 - [Meeting Notes / Recordings](https://docs.google.com/document/d/1OUWifNf7hZ_QH3m1J3zjSUUk11yKUZnvom1BS2KxrUQ)
 - [Project Board (Private)](https://github.com/orgs/kubeflow/projects/84)
 - Contact
-  - [#kubeflow-platform](https://cloud-native.slack.com/archives/C073W572LA2) on slack
+  - [#kubeflow-community-distribution](https://cloud-native.slack.com/archives/C073W572LA2) on slack
   - [#kubeflow-release-team](https://cloud-native.slack.com/archives/C0ACZPHKR9N) on slack
-  - [@release-team](https://github.com/orgs/kubeflow/teams/release-team) on GitHub
+  - [@kubeflow/release-team](https://github.com/orgs/kubeflow/teams/release-team) on GitHub
 
 ### TL;DR
 

--- a/releases/release-26.10/release-team.md
+++ b/releases/release-26.10/release-team.md
@@ -1,11 +1,11 @@
-# Kubeflow AI Reference Platform 26.10 Release Team
+# Kubeflow Community Distribution 26.10 Release Team
 
 | **Role** | **Name (GitHub / Slack ID)** |
 |:---|:---|
 | **Release Manager** | Dominik Kawka (GitHub: [@dominikkawka](https://github.com/dominikkawka) / Slack: `Dominik Kawka`) |
 | **Release Manager Shadows** | Dhanisha Phadate (GitHub: [@dhanishaphadate](https://github.com/dhanishaphadate) / Slack: `Dhanisha Phadate`) <br> Artur Martins (GitHub: [@arturmartins](https://github.com/arturmartins) / Slack: `Artur Martins`) <br> Alyssa Goins (GitHub: [@alyssacgoins](https://github.com/alyssacgoins) / Slack: `Alyssa Goins`) |
 | **Product Manager** | Dhanisha Phadate (GitHub: [@dhanishaphadate](https://github.com/dhanishaphadate) / Slack: `Dhanisha Phadate`) |
-| **Training WG Liaison(s)** |  |
+| **Training WG Liaison(s)** | Rob Bell (GitHub: [@robert-bell](https://github.com/robert-bell) / Slack: `Rob Bell`) |
 | **Notebooks WG Liaison(s)** | Christian Heusel (GitHub: [@christian-heusel](https://github.com/christian-heusel) / Slack: `Christian Heusel`) |
 | **Kubeflow Community Distribution WG Liaison(s)** | Tarek Abouzeid (GitHub: [@tarekabouzeid](https://github.com/tarekabouzeid) / Slack: `Tarek Abouzeid`) |
 | **Pipelines WG Liaison(s)** | Alyssa Goins (GitHub: [@alyssacgoins](https://github.com/alyssacgoins) / Slack: `Alyssa Goins`) |

--- a/releases/release-26.10/release-team.md
+++ b/releases/release-26.10/release-team.md
@@ -1,0 +1,18 @@
+# Kubeflow AI Reference Platform 26.10 Release Team
+
+| **Role** | **Name (GitHub / Slack ID)** |
+|:---|:---|
+| **Release Manager** | Dominik Kawka (GitHub: [@dominikkawka](https://github.com/dominikkawka) / Slack: `Dominik Kawka`) |
+| **Release Manager Shadows** | Dhanisha Phadate (GitHub: [@dhanishaphadate](https://github.com/dhanishaphadate) / Slack: `Dhanisha Phadate`) <br> Artur Martins (GitHub: [@arturmartins](https://github.com/arturmartins) / Slack: `Artur Martins`) <br> Alyssa Goins (GitHub: [@alyssacgoins](https://github.com/alyssacgoins) / Slack: `Alyssa Goins`) |
+| **Product Manager** | Dhanisha Phadate (GitHub: [@dhanishaphadate](https://github.com/dhanishaphadate) / Slack: `Dhanisha Phadate`) |
+| **Training WG Liaison(s)** |  |
+| **Notebooks WG Liaison(s)** | Christian Heusel (GitHub: [@christian-heusel](https://github.com/christian-heusel) / Slack: `Christian Heusel`) |
+| **Kubeflow Community Distribution WG Liaison(s)** | Tarek Abouzeid (GitHub: [@tarekabouzeid](https://github.com/tarekabouzeid) / Slack: `Tarek Abouzeid`) |
+| **Pipelines WG Liaison(s)** | Alyssa Goins (GitHub: [@alyssacgoins](https://github.com/alyssacgoins) / Slack: `Alyssa Goins`) |
+| **Spark Operator (WG Data)** |  |
+| **Kubeflow Hub (WG Data)** | Adysen Rothman (GitHub: [@adysenrothman](https://github.com/adysenrothman) / Slack: `Adysen Rothman`) |
+| **KServe Liaison(s)** | Vraj Bhatt (GitHub: [@vrajjbhatt](https://github.com/vrajjbhatt) / Slack: `Vraj Bhatt`) |
+| **KDC Liaison(s)** | |
+
+- The definition of the release team roles and responsibilities can be found at [release handbook](../kubeflow-community-distribution-release-handbook.md)
+- The timeline for the release can be found [here](README.md).

--- a/releases/release-26.10/release-team.md
+++ b/releases/release-26.10/release-team.md
@@ -9,10 +9,9 @@
 | **Notebooks WG Liaison(s)** | Christian Heusel (GitHub: [@christian-heusel](https://github.com/christian-heusel) / Slack: `Christian Heusel`) |
 | **Kubeflow Community Distribution WG Liaison(s)** | Tarek Abouzeid (GitHub: [@tarekabouzeid](https://github.com/tarekabouzeid) / Slack: `Tarek Abouzeid`) |
 | **Pipelines WG Liaison(s)** | Alyssa Goins (GitHub: [@alyssacgoins](https://github.com/alyssacgoins) / Slack: `Alyssa Goins`) |
-| **Spark Operator (WG Data)** |  |
+| **Spark Operator (WG Data)** | Manabu McClosley (GitHub: [@nabuskey](https://github.com/nabuskey) / Slack: `Manabu McCloskey`) |
 | **Kubeflow Hub (WG Data)** | Adysen Rothman (GitHub: [@adysenrothman](https://github.com/adysenrothman) / Slack: `Adysen Rothman`) |
 | **KServe Liaison(s)** | Vraj Bhatt (GitHub: [@vrajjbhatt](https://github.com/vrajjbhatt) / Slack: `Vraj Bhatt`) |
-| **KDC Liaison(s)** | |
 
 - The definition of the release team roles and responsibilities can be found at [release handbook](../kubeflow-community-distribution-release-handbook.md)
 - The timeline for the release can be found [here](README.md).

--- a/releases/retrospectives/release-26.03.md
+++ b/releases/retrospectives/release-26.03.md
@@ -14,6 +14,6 @@
 - Meetings landed on Bank holidays 2-3 times during 26.03 release
 - 26.03 release cut really close to KubeCon EU; there was no 26.03 reference platform page during the event
 - Recording for 26.03 and 26.03.1 went well, it was good to have many liaisons on at the same time, although the video had gone long at some point, possibly limiting each component to 1-2 minutes to keep the video short and sweet, or editing down the recording to make it more digestible.
-- 26.03 and 26.03.1; had breaking changes, and some components were only updated in the patch release. 26.03.1 had robust instructions for updating
-- A lot of components had many big changes included, it was difficult to get it done right and synced, not enough engineers/ resources to manage. More people have started getting involved since, shouldn’t be as big of a load to carry. 
-- Release Manager Handover hasn’t been as smooth, having a written down process for next release, and noting which permissions need to be handed over.
+- 26.03 and 26.03.1 had breaking changes, and some components were only updated in the patch release. 26.03.1 had robust instructions for updating
+- A lot of components included large changes; it was difficult to get it done right and synchronized, and there were not enough engineers and resources to manage it. More people have started getting involved since, so it shouldn’t be as big of a load to carry.
+- Release manager handover hasn’t been as smooth; we should write down the process for the next release and note which permissions need to be handed over.

--- a/releases/retrospectives/release-26.03.md
+++ b/releases/retrospectives/release-26.03.md
@@ -2,8 +2,8 @@
 
 ### Links
 - [Handbook](../kubeflow-community-distribution-release-handbook.md)
-- [Release Team](../release-26.10/release-team.md)
-- [Timeline](../release-26.10/README.md)
+- [Release Team](../release-26.03/release-team.md)
+- [Timeline](../release-26.03/README.md)
 
 ### Rules
 - Respectful, solution-oriented communication

--- a/releases/retrospectives/release-26.03.md
+++ b/releases/retrospectives/release-26.03.md
@@ -1,0 +1,19 @@
+# Kubeflow 26.03 Release Retrospective
+
+### Links
+- [Handbook](../kubeflow-community-distribution-release-handbook.md)
+- [Release Team](../release-26.10/release-team.md)
+- [Timeline](../release-26.10/README.md)
+
+### Rules
+- Respectful, solution-oriented communication
+- Solutions are found in changing our process and tooling, not in blaming/shaming
+
+## What could have gone better ⚠️
+
+- Meetings landed on Bank holidays 2-3 times during 26.03 release
+- 26.03 release cut really close to KubeCon EU; there was no 26.03 reference platform page during the event
+- Recording for 26.03 and 26.03.1 went well, it was good to have many liaisons on at the same time, although the video had gone long at some point, possibly limiting each component to 1-2 minutes to keep the video short and sweet, or editing down the recording to make it more digestible.
+- 26.03 and 26.03.1; had breaking changes, and some components were only updated in the patch release. 26.03.1 had robust instructions for updating
+- A lot of components had many big changes included, it was difficult to get it done right and synced, not enough engineers/ resources to manage. More people have started getting involved since, shouldn’t be as big of a load to carry. 
+- Release Manager Handover hasn’t been as smooth, having a written down process for next release, and noting which permissions need to be handed over.

--- a/releases/retrospectives/release-26.03.md
+++ b/releases/retrospectives/release-26.03.md
@@ -12,7 +12,7 @@
 ## What could have gone better ⚠️
 
 - Meetings landed on Bank holidays 2-3 times during 26.03 release
-- 26.03 release cut really close to KubeCon EU; there was no 26.03 reference platform page during the event
+- 26.03 release cut really close to KubeCon EU; there was no 26.03 reference platform page on the Kubeflow website during the event
 - Recording for 26.03 and 26.03.1 went well, it was good to have many liaisons on at the same time, although the video had gone long at some point, possibly limiting each component to 1-2 minutes to keep the video short and sweet, or editing down the recording to make it more digestible.
 - 26.03 and 26.03.1 had breaking changes, and some components were only updated in the patch release. 26.03.1 had robust instructions for updating
 - A lot of components included large changes; it was difficult to get it done right and synchronized, and there were not enough engineers and resources to manage it. More people have started getting involved since, so it shouldn’t be as big of a load to carry.


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests
cc: @tarekabouzeid @juliusvonkohout @dhanishaphadate @alyssacgoins @arturmartins @christian-heusel @adysenrothman

## ✏️ Summary of Changes
WORK IN PROGRESS:
assembling release v26.10 team and roadmap, as discussed in the Community Distribution meeting 22/June/2026.

Once PR is ready to merge I will squash the commits

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.

## ✅ Contributor Checklist

- [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---

> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-community-distribution**](https://cloud-native.slack.com/archives/C073W572LA2).
