### PR TITLE
helm: update cert-manager chart metadata

### DIFF
--- a/common/cert-manager/helm/Chart.yaml
+++ b/common/cert-manager/helm/Chart.yaml
@@ -7,10 +7,10 @@ keywords:
 - cert-manager
 - kubeflow
 - certificates
-home: https://github.com/kubeflow/manifests
+home: https://github.com/kubeflow/community-distribution
 sources:
 - https://cert-manager.io
-- https://github.com/kubeflow/manifests
+- https://github.com/kubeflow/community-distribution/tree/master/common/cert-manager
 dependencies:
 - name: cert-manager
   version: "1.20.2"

--- a/scripts/synchronize-cert-manager-manifests.sh
+++ b/scripts/synchronize-cert-manager-manifests.sh
@@ -11,6 +11,14 @@ MANIFESTS_DIRECTORY="$(dirname "$SCRIPT_DIRECTORY")"
 DESTINATION_DIRECTORY="$MANIFESTS_DIRECTORY/common/${COMPONENT_NAME}"
 DESTINATION_FILE="$DESTINATION_DIRECTORY/base/upstream/cert-manager.yaml"
 CHART_DIRECTORY="$DESTINATION_DIRECTORY/helm"
+HELM_HOME_DIRECTORY="$(mktemp -d)"
+cleanup() {
+  rm -rf "$HELM_HOME_DIRECTORY"
+}
+trap cleanup EXIT
+export HELM_CACHE_HOME="$HELM_HOME_DIRECTORY/cache"
+export HELM_CONFIG_HOME="$HELM_HOME_DIRECTORY/config"
+export HELM_DATA_HOME="$HELM_HOME_DIRECTORY/data"
 create_branch "$BRANCH_NAME"
 wget -O "$DESTINATION_FILE" \
   "https://github.com/${REPOSITORY_NAME}/releases/download/${COMMIT}/cert-manager.yaml"


### PR DESCRIPTION
## Summary

- Updates the cert-manager wrapper chart metadata to reference the current `kubeflow/community-distribution` repository.
- Keeps chart behavior, dependencies, rendered manifests, and README install commands unchanged.
- Limits this follow-up to stale repository metadata after review feedback on chart metadata naming.

## Validation

- `helm dependency build common/cert-manager/helm`
- `helm lint common/cert-manager/helm`
- `./tests/helm_kustomize_compare.sh cert-manager base`
- `./tests/helm_kustomize_compare.sh cert-manager kubeflow`
- `./tests/helm_kustomize_compare.sh cert-manager existing-cert-manager`
- `git diff --check`
