### PR TITLE
Restore defaultProviders.metrics in oauth2-proxy istio mesh config

### DIFF
--- a/common/oauth2-proxy/components/istio-external-auth-patches/patches/cm.enable-oauth2-proxy.yaml
+++ b/common/oauth2-proxy/components/istio-external-auth-patches/patches/cm.enable-oauth2-proxy.yaml
@@ -10,6 +10,9 @@ data:
       discoveryAddress: istiod.istio-system.svc:15012
       proxyMetadata: {}
       tracing: {}
+    defaultProviders:
+      metrics:
+      - prometheus
     enablePrometheusMerge: true
     rootNamespace: istio-system
     tcpKeepalive:


### PR DESCRIPTION
## ✏️ Summary of Changes

The `istio-external-auth-patches` component replaces the entire istio mesh
config string in the `istio` ConfigMap (istio-system) to add the oauth2-proxy
`extensionProviders`. In doing so it dropped `defaultProviders.metrics:
[prometheus]`, which the base istio install ships
(`common/istio/istio-install/base/install.yaml`).

Without `defaultProviders.metrics`, istiod stops injecting the `istio.stats`
telemetry filter into the sidecar listeners. As a result `istio_requests_total`
is never produced, Prometheus scrapes empty telemetry, and Kiali traffic graphs
stay empty even though the mesh is healthy and serving traffic.
Istio standard telemetry metrics (including istio_requests_total) are no longer emitted.

This restores the three missing lines so the patched mesh config matches the
base install:

```yaml
    defaultProviders:
      metrics:
      - prometheus
```

Verification:

```bash
kustomize build example \
  | yq 'select(.kind=="ConfigMap" and .metadata.name=="istio") | .data.mesh' \
  | grep -A2 defaultProviders
```

Before: no `defaultProviders` in the rendered istio ConfigMap.
After:  `defaultProviders.metrics: [prometheus]` present alongside the
        oauth2-proxy `extensionProviders`.

## 📦 Dependencies

None.

## 🐛 Related Issues

None. Straightforward regression fix restoring parity with the base istio
install configuration.

## ✅ Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).