### PR TITLE
fix: align KServe UI Helm image tag with Kustomize

### DIFF
--- a/experimental/helm/charts/kserve-ui/values.yaml
+++ b/experimental/helm/charts/kserve-ui/values.yaml
@@ -19,7 +19,7 @@ global:
   # -- Image registry for KServe Models Web App images
   imageRegistry: ghcr.io/kserve
   # -- Global image tag for KServe Models Web App
-  imageTag: 1.0.0
+  imageTag: latest
   # -- Global image pull policy
   imagePullPolicy: Always
   # -- Global image pull secrets


### PR DESCRIPTION
## Summary of Changes
Align the KServe UI Helm default image tag with the Kustomize manifests.
This fixes the Helm versus Kustomize parity check for `kserve-models-web-application` in both supported scenarios.

Reproduce before the fix:
```sh
PATH="$HOME/.local/bin:$PATH" ./tests/helm_kustomize_compare.sh kserve-models-web-application base
PATH="$HOME/.local/bin:$PATH" ./tests/helm_kustomize_compare.sh kserve-models-web-application kubeflow
```
Both commands fail on the rendered `Deployment` image field.

Verified after the fix:
```sh
PATH="$HOME/.local/bin:$PATH" ./tests/helm_kustomize_compare.sh kserve-models-web-application base
PATH="$HOME/.local/bin:$PATH" ./tests/helm_kustomize_compare.sh kserve-models-web-application kubeflow
PATH="$HOME/.local/bin:$PATH" ./tests/helm_kustomize_compare_all.sh
```

## Dependencies
None.

## Related Issues
None found.

## Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
