### PR TITLE
helm: align Hub chart with v0.3.12 manifests

### DIFF
--- a/experimental/helm/charts/hub/ci/ci-values.yaml
+++ b/experimental/helm/charts/hub/ci/ci-values.yaml
@@ -12,7 +12,7 @@ server:
   dataStoreType: embedmd
 
   image:
-    tag: "v0.3.10"
+    tag: "v0.3.12"
 
   # Configure readiness probe
   rest:

--- a/experimental/helm/charts/hub/ci/values-db.yaml
+++ b/experimental/helm/charts/hub/ci/values-db.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.10"
+    tag: "v0.3.12"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/hub/ci/values-istio.yaml
+++ b/experimental/helm/charts/hub/ci/values-istio.yaml
@@ -29,7 +29,11 @@ istio:
       - source:
           principals:
           - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
-    - when:
+    - from:
+      - source:
+          namespaces:
+          - "kubeflow"
+      when:
       - key: request.headers[authorization]
         values:
         - "*"
@@ -62,4 +66,4 @@ monitoring:
   
 storage:
   csi:
-    enabled: false 
+    enabled: false

--- a/experimental/helm/charts/hub/ci/values-postgres.yaml
+++ b/experimental/helm/charts/hub/ci/values-postgres.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.10"
+    tag: "v0.3.12"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/hub/ci/values-ui-integrated.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-integrated.yaml
@@ -5,7 +5,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.10"
+    tag: "v0.3.12"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui-istio.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-istio.yaml
@@ -9,7 +9,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.10"
+    tag: "v0.3.12"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui-standalone.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-standalone.yaml
@@ -9,7 +9,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.10"
+    tag: "v0.3.12"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui.yaml
@@ -5,7 +5,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.10"
+    tag: "v0.3.12"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui.yaml
@@ -4,7 +4,6 @@ ui:
   replicas: 1
 
   image:
-    repository: ui
     tag: "v0.3.12"
     pullPolicy: Always
 

--- a/experimental/helm/charts/hub/values.yaml
+++ b/experimental/helm/charts/hub/values.yaml
@@ -18,7 +18,7 @@ global:
   # -- Image registry for Model Registry images
   imageRegistry: ghcr.io/kubeflow/hub
   # -- Global image tag for all Model Registry components
-  imageTag: v0.3.10
+  imageTag: v0.3.12
   # -- Global image pull policy
   imagePullPolicy: IfNotPresent
   # -- Global image pull secrets

--- a/experimental/helm/charts/hub/values.yaml
+++ b/experimental/helm/charts/hub/values.yaml
@@ -176,7 +176,7 @@ ui:
 
   image:
     # -- UI image repository
-    repository: model-registry-ui
+    repository: ui
     # -- UI image tag
     tag: ""
     # -- UI image pull policy


### PR DESCRIPTION
## Summary of Changes

Aligns the existing Hub Helm chart parity values with the `v0.3.12` Kustomize manifests introduced by [#3548](https://github.com/kubeflow/community-distribution/pull/3548).

- updates Hub server and UI default/CI image tags from `v0.3.10` to `v0.3.12`
- mirrors the new `kubeflow` source-namespace restriction in the Istio comparison values
- restores the repository-wide Helm/Kustomize comparison matrix

This is a focused parity repair. Extending `scripts/synchronize-hub-manifests.sh` to update Helm surfaces remains separate follow-up work.

## Dependencies

None. This follows the upstream Hub synchronization in [#3548](https://github.com/kubeflow/community-distribution/pull/3548).

## Related Issues

This unblocks the shared comparison workflow on [#3480](https://github.com/kubeflow/community-distribution/pull/3480), [#3525](https://github.com/kubeflow/community-distribution/pull/3525), and [#3524](https://github.com/kubeflow/community-distribution/pull/3524).

## Validation

- `helm lint experimental/helm/charts/hub/` with Helm `v4.2.2`
- `./tests/helm_kustomize_compare_all.sh hub`
- `./tests/helm_kustomize_compare_all.sh`
- `git diff --check`

The complete repository comparison matrix passes locally under Helm `v4.2.2` and Kustomize `v5.8.1`.

## Contributor Checklist

- [x] I have tested these changes with Kustomize through the Helm/Kustomize comparison matrix.
- [x] All commits are signed off to satisfy the DCO check.
- [ ] I have considered adding my company to the adopters page.