### PR TITLE
Update kubeflow/hub manifests from v0.3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This repository periodically synchronizes all official Kubeflow components from 
 | KServe UI | applications/kserve/kserve-ui | [v1.0.1](https://github.com/kserve/models-web-app/tree/v1.0.1/manifests/kustomize) | 6m | 259Mi | 0GB |
 | KServe | applications/kserve/kserve | [v0.19.0](https://github.com/kserve/kserve/tree/v0.19.0) | 600m | 1200Mi | 0GB |
 | Kubeflow Pipelines | applications/pipeline/upstream | [2.17.0](https://github.com/kubeflow/pipelines/tree/2.17.0/manifests/kustomize) | 970m | 3552Mi | 35GB |
-| Kubeflow Hub | applications/hub/upstream | [v0.3.12](https://github.com/kubeflow/hub/tree/v0.3.12/manifests/kustomize) | 510m | 2112Mi | 20GB |
+| Kubeflow Hub | applications/hub/upstream | [v0.3.14](https://github.com/kubeflow/hub/tree/v0.3.14/manifests/kustomize) | 510m | 2112Mi | 20GB |
 | Spark Operator | applications/spark/spark-operator | [2.5.1](https://github.com/kubeflow/spark-operator/tree/v2.5.1) | 9m | 41Mi | 0GB |
 | Istio | common/istio | [1.30.3](https://github.com/istio/istio/releases/tag/1.30.3) | 750m | 2364Mi | 0GB |
 | Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.22.0](https://github.com/knative/serving/releases/tag/knative-v1.22.0) <br /> [v1.22.0](https://github.com/knative/eventing/releases/tag/knative-v1.22.0) | 1450m | 1038Mi | 0GB |

--- a/applications/hub/upstream/base/kustomization.yaml
+++ b/applications/hub/upstream/base/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 images:
 - name: ghcr.io/kubeflow/hub/server
   newName: ghcr.io/kubeflow/hub/server
-  newTag: v0.3.12
+  newTag: v0.3.14

--- a/applications/hub/upstream/options/catalog/base/deployment.yaml
+++ b/applications/hub/upstream/options/catalog/base/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       - name: sources
         configMap:
           name: model-catalog-sources
+      - name: mcp-sources
+        configMap:
+          name: mcp-catalog-sources
       containers:
         - name: catalog
           env:
@@ -56,6 +59,7 @@ spec:
           args:
             - --listen=0.0.0.0:8080
             - --catalogs-path=/catalog/sources.yaml
+            - --catalogs-path=/mcp-catalog/sources.yaml
           image: ghcr.io/kubeflow/hub/server:latest
           ports:
             - name: http-api
@@ -80,3 +84,5 @@ spec:
           volumeMounts:
           - name: sources
             mountPath: /catalog
+          - name: mcp-sources
+            mountPath: /mcp-catalog

--- a/applications/hub/upstream/options/catalog/base/kustomization.yaml
+++ b/applications/hub/upstream/options/catalog/base/kustomization.yaml
@@ -14,6 +14,12 @@ configMapGenerator:
   name: model-catalog-sources
   options:
     disableNameSuffixHash: true
+- behavior: create
+  files:
+  - sources.yaml=mcp-sources.yaml
+  name: mcp-catalog-sources
+  options:
+    disableNameSuffixHash: true
 
 secretGenerator:
 - envs:
@@ -29,4 +35,4 @@ secretGenerator:
 images:
 - name: ghcr.io/kubeflow/hub/server
   newName: ghcr.io/kubeflow/hub/server
-  newTag: v0.3.12
+  newTag: v0.3.14

--- a/applications/hub/upstream/options/catalog/base/mcp-sources.yaml
+++ b/applications/hub/upstream/options/catalog/base/mcp-sources.yaml
@@ -1,0 +1,1 @@
+mcp_catalogs: []

--- a/applications/hub/upstream/options/csi/clusterstoragecontainer.yaml
+++ b/applications/hub/upstream/options/csi/clusterstoragecontainer.yaml
@@ -9,6 +9,12 @@ spec:
     env:
     - name: MODEL_REGISTRY_BASE_URL
       value: "model-registry-service.kubeflow.svc.cluster.local:8080"
+    # Uncomment to restrict artifact URIs the storage-initializer will download.
+    # Comma-separated list of URI prefixes. If unset, all URIs with supported
+    # protocols are allowed. Use trailing slashes to avoid partial bucket name
+    # matches (e.g., "s3://my-bucket/" not "s3://my-bucket").
+    # - name: ALLOWED_ARTIFACT_URI_PREFIXES
+    #   value: "s3://my-trusted-bucket/,gs://my-gcs-bucket/"
     resources:
       requests:
         memory: 100Mi

--- a/applications/hub/upstream/options/csi/kustomization.yaml
+++ b/applications/hub/upstream/options/csi/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: ghcr.io/kubeflow/hub/storage-initializer
   newName: ghcr.io/kubeflow/hub/storage-initializer
-  newTag: v0.3.12
+  newTag: v0.3.14

--- a/applications/hub/upstream/options/ui/base/kustomization.yaml
+++ b/applications/hub/upstream/options/ui/base/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: model-registry-ui
   newName: ghcr.io/kubeflow/hub/ui
-  newTag: v0.3.12
+  newTag: v0.3.14

--- a/scripts/synchronize-hub-manifests.sh
+++ b/scripts/synchronize-hub-manifests.sh
@@ -6,7 +6,7 @@ setup_error_handling
 COMPONENT_NAME="hub"
 REPOSITORY_NAME="kubeflow/hub"
 REPOSITORY_URL="https://github.com/kubeflow/hub.git"
-COMMIT="v0.3.12"
+COMMIT="v0.3.14"
 REPOSITORY_DIRECTORY="hub"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/kubeflow-${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-kubeflow-${COMPONENT_NAME}-manifests-${COMMIT?}}


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Updating manifests from the latest release of Hub.

## 📦 Dependencies
None

## 🐛 Related Issues
None

## ✅ Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---

> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-community-distribution**](https://cloud-native.slack.com/archives/C073W572LA2).
