### PR TITLE
helm: restore Hub v0.3.14 parity

### DIFF
--- a/.github/workflows/helm-kustomize-comparison.yml
+++ b/.github/workflows/helm-kustomize-comparison.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
     - experimental/helm/charts/**
+    - applications/hub/**
     - applications/kserve/kserve-ui/**
     - common/cert-manager/**
     - common/kubeflow-namespace/**
     - common/kubeflow-roles/**
     - scripts/synchronize-cert-manager-manifests.sh
+    - scripts/synchronize-hub-manifests.sh
     - tests/kustomize_install.sh
     - tests/helm_kustomize_compare.py
     - tests/helm_kustomize_compare.sh

--- a/experimental/helm/charts/hub/ci/ci-values.yaml
+++ b/experimental/helm/charts/hub/ci/ci-values.yaml
@@ -12,7 +12,7 @@ server:
   dataStoreType: embedmd
 
   image:
-    tag: "v0.3.12"
+    tag: "v0.3.14"
 
   # Configure readiness probe
   rest:

--- a/experimental/helm/charts/hub/ci/values-db.yaml
+++ b/experimental/helm/charts/hub/ci/values-db.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.12"
+    tag: "v0.3.14"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/hub/ci/values-postgres.yaml
+++ b/experimental/helm/charts/hub/ci/values-postgres.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.12"
+    tag: "v0.3.14"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/hub/ci/values-ui-integrated.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-integrated.yaml
@@ -5,7 +5,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.12"
+    tag: "v0.3.14"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui-istio.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-istio.yaml
@@ -9,7 +9,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.12"
+    tag: "v0.3.14"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui-standalone.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-standalone.yaml
@@ -9,7 +9,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.12"
+    tag: "v0.3.14"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui.yaml
@@ -4,7 +4,7 @@ ui:
   replicas: 1
 
   image:
-    tag: "v0.3.12"
+    tag: "v0.3.14"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/values.yaml
+++ b/experimental/helm/charts/hub/values.yaml
@@ -18,7 +18,7 @@ global:
   # -- Image registry for Model Registry images
   imageRegistry: ghcr.io/kubeflow/hub
   # -- Global image tag for all Model Registry components
-  imageTag: v0.3.12
+  imageTag: v0.3.14
   # -- Global image pull policy
   imagePullPolicy: IfNotPresent
   # -- Global image pull secrets

--- a/scripts/synchronize-hub-manifests.sh
+++ b/scripts/synchronize-hub-manifests.sh
@@ -28,9 +28,9 @@ DESTINATION_TEXT="\[${COMMIT}\](https://github.com/${REPOSITORY_NAME}/tree/${COM
 create_branch "$BRANCH_NAME"
 clone_and_checkout "$SOURCE_DIRECTORY" "$REPOSITORY_URL" "$REPOSITORY_DIRECTORY" "$COMMIT"
 copy_manifests "${SOURCE_DIRECTORY}/${REPOSITORY_DIRECTORY}/${SOURCE_MANIFESTS_PATH}" "${MANIFESTS_DIRECTORY}/${DESTINATION_MANIFESTS_PATH}"
-sed -i "s|^  imageTag: v[0-9.]*|  imageTag: ${COMMIT}|" "${HELM_CHART_DIRECTORY}/values.yaml"
+sed -i "s|^  imageTag: .*|  imageTag: ${COMMIT}|" "${HELM_CHART_DIRECTORY}/values.yaml"
 for helm_ci_values_file in "${HELM_CI_VALUES_FILES[@]}"; do
-  sed -i "s|tag: \"v[0-9.]*\"|tag: \"${COMMIT}\"|" "$helm_ci_values_file"
+  sed -i "s|^    tag: \"v[^\"]*\"$|    tag: \"${COMMIT}\"|" "$helm_ci_values_file"
 done
 update_readme "$MANIFESTS_DIRECTORY" "$SOURCE_TEXT" "$DESTINATION_TEXT"
 commit_changes "$MANIFESTS_DIRECTORY" "Update ${REPOSITORY_NAME} manifests from ${COMMIT}" "$MANIFESTS_DIRECTORY"

--- a/scripts/synchronize-hub-manifests.sh
+++ b/scripts/synchronize-hub-manifests.sh
@@ -11,6 +11,16 @@ REPOSITORY_DIRECTORY="hub"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/kubeflow-${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-kubeflow-${COMPONENT_NAME}-manifests-${COMMIT?}}
 MANIFESTS_DIRECTORY=$(dirname $SCRIPT_DIRECTORY)
+HELM_CHART_DIRECTORY="${MANIFESTS_DIRECTORY}/experimental/helm/charts/${COMPONENT_NAME}"
+HELM_CI_VALUES_FILES=(
+  "${HELM_CHART_DIRECTORY}/ci/ci-values.yaml"
+  "${HELM_CHART_DIRECTORY}/ci/values-db.yaml"
+  "${HELM_CHART_DIRECTORY}/ci/values-postgres.yaml"
+  "${HELM_CHART_DIRECTORY}/ci/values-ui.yaml"
+  "${HELM_CHART_DIRECTORY}/ci/values-ui-standalone.yaml"
+  "${HELM_CHART_DIRECTORY}/ci/values-ui-integrated.yaml"
+  "${HELM_CHART_DIRECTORY}/ci/values-ui-istio.yaml"
+)
 SOURCE_MANIFESTS_PATH="manifests/kustomize"
 DESTINATION_MANIFESTS_PATH="applications/${COMPONENT_NAME}/upstream"
 SOURCE_TEXT="\[.*\](https://github.com/${REPOSITORY_NAME}/tree/.*/manifests/kustomize)"
@@ -18,6 +28,10 @@ DESTINATION_TEXT="\[${COMMIT}\](https://github.com/${REPOSITORY_NAME}/tree/${COM
 create_branch "$BRANCH_NAME"
 clone_and_checkout "$SOURCE_DIRECTORY" "$REPOSITORY_URL" "$REPOSITORY_DIRECTORY" "$COMMIT"
 copy_manifests "${SOURCE_DIRECTORY}/${REPOSITORY_DIRECTORY}/${SOURCE_MANIFESTS_PATH}" "${MANIFESTS_DIRECTORY}/${DESTINATION_MANIFESTS_PATH}"
+sed -i "s|^  imageTag: v[0-9.]*|  imageTag: ${COMMIT}|" "${HELM_CHART_DIRECTORY}/values.yaml"
+for helm_ci_values_file in "${HELM_CI_VALUES_FILES[@]}"; do
+  sed -i "s|tag: \"v[0-9.]*\"|tag: \"${COMMIT}\"|" "$helm_ci_values_file"
+done
 update_readme "$MANIFESTS_DIRECTORY" "$SOURCE_TEXT" "$DESTINATION_TEXT"
 commit_changes "$MANIFESTS_DIRECTORY" "Update ${REPOSITORY_NAME} manifests from ${COMMIT}" "$MANIFESTS_DIRECTORY"
 echo "Synchronization completed successfully."

--- a/tests/resynchronize-upstream-changes.py
+++ b/tests/resynchronize-upstream-changes.py
@@ -35,7 +35,11 @@ def find_upstream_scripts(changed_files: list[Path]) -> set[Path]:
     upstream_scripts = set()
     for changed in changed_files:
         for upstream_path, script in path_to_synchronization_script.items():
-            if upstream_path in changed.parents or changed == upstream_path:
+            if (
+                changed == script
+                or upstream_path in changed.parents
+                or changed == upstream_path
+            ):
                 upstream_scripts.add(script)
     return upstream_scripts
 


### PR DESCRIPTION
## Problem

[kubeflow/community-distribution#3555](https://github.com/kubeflow/community-distribution/pull/3555) updated the Hub Kustomize manifests to `v0.3.14`, while the Hub Helm chart and comparison values remained at `v0.3.12`. This caused the repository-wide Helm and Kustomize comparison to fail in the [Istio pull request comparison job](https://github.com/kubeflow/community-distribution/actions/runs/29700418633/job/88228436524).

## Changes

- Align the Hub Helm default image tag and comparison values with `v0.3.14`.
- Extend `scripts/synchronize-hub-manifests.sh` so future Hub manifest updates also update the Helm version surfaces.
- Run the Helm and Kustomize comparison workflow when Hub Kustomize manifests or the Hub synchronization script change.

## Validation

- `bash -n scripts/synchronize-hub-manifests.sh`
- `helm lint experimental/helm/charts/hub/`
- `./tests/helm_kustomize_compare_all.sh hub`
- `./tests/helm_kustomize_compare_all.sh`
- No-commit execution of `scripts/synchronize-hub-manifests.sh` for `v0.3.14`, with no additional repository differences.
- `git diff --check`
