### PR TITLE
feat: Right-size default istio-proxy sidecar resources

### DIFF
--- a/common/istio/istio-install/base/install.yaml
+++ b/common/istio/istio-install/base/install.yaml
@@ -3246,12 +3246,12 @@ data:
           "readinessPeriodSeconds": 15,
           "resources": {
             "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
+              "cpu": "200m",
+              "memory": "128Mi"
             },
             "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
+              "cpu": "25m",
+              "memory": "64Mi"
             }
           },
           "seccompProfile": {},
@@ -3429,12 +3429,12 @@ data:
           "readinessPeriodSeconds": 15,
           "resources": {
             "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
+              "cpu": "200m",
+              "memory": "128Mi"
             },
             "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
+              "cpu": "25m",
+              "memory": "64Mi"
             }
           },
           "seccompProfile": {},
@@ -3584,6 +3584,18 @@ data:
         "configValidation": true,
         "hub": "registry.istio.io/release",
         "istioNamespace": "istio-system",
+        "proxy": {
+          "resources": {
+            "limits": {
+              "cpu": "200m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "25m",
+              "memory": "64Mi"
+            }
+          }
+        },
         "tag": "1.30.3"
       },
       "meshConfig": {

--- a/common/istio/profile-overlay.yaml
+++ b/common/istio/profile-overlay.yaml
@@ -6,6 +6,20 @@ spec:
       time: 10s
       interval: 5s
       probes: 3
+  values:
+    global:
+      proxy:
+        # Default sidecars are injected into low-traffic internal services
+        # (Kubeflow control-plane components), so size them accordingly
+        # instead of the upstream defaults (100m/128Mi request, 2000m/1024Mi
+        # limit) which are tuned for higher-throughput data-plane proxies.
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
   components:
     ingressGateways:
     - enabled: true


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

Kubeflow's injected sidecars mostly front low-traffic internal
control-plane components (dashboards, controllers, webhooks), not
high-throughput data-plane services. Live usage measured across 42
sidecars in a running cluster showed 2-6m CPU and 65-105Mi memory actual
consumption against the upstream defaults of 100m CPU / 128Mi memory
requests and 2000m CPU / 1024Mi memory limits.

To fix this, set `global.proxy.resources` to 25m / 64Mi request and 200m
/ 128Mi limit, in line with published guidance for low-traffic internal
service sidecars.

## 📦 Dependencies

_None_

## 🐛 Related Issues

_None_

## ✅ Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/community-distribution#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
