### PR TITLE
ci: address Istio Helm review feedback

### DIFF
--- a/.github/workflows/helm-kustomize-comparison.yml
+++ b/.github/workflows/helm-kustomize-comparison.yml
@@ -91,7 +91,9 @@ jobs:
       with:
         version: v4.2.2
     - name: Install Kustomize
-      run: ./tests/kustomize_install.sh
+      run: |
+        ./tests/kustomize_install.sh
+        echo "/tmp/usr/local/bin" >> "$GITHUB_PATH"
     - name: Test Istio Helm behavior
       run: python tests/test_istio_helm_chart.py
     - name: Compare Istio Helm and Kustomize manifests

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -112,7 +112,7 @@ update_helm_chart_application_version() (
     return $?
   fi
 
-  if temporary_chart="$(mktemp "${chart_yaml}.tmp.XXXXXX")"; then
+  if temporary_chart="$(mktemp "${chart_yaml}.temporary.XXXXXX")"; then
     :
   else
     return $?
@@ -160,7 +160,7 @@ write_generated_file_atomically() (
     return 1
   fi
 
-  if temporary_file="$(mktemp "${destination_file}.tmp.XXXXXX")"; then
+  if temporary_file="$(mktemp "${destination_file}.temporary.XXXXXX")"; then
     :
   else
     return $?

--- a/tests/helm_kustomize_compare.py
+++ b/tests/helm_kustomize_compare.py
@@ -275,7 +275,12 @@ def preserve_cert_manager_kubeflow_labels(original: Dict, normalized: Dict) -> N
         )
 
 
-def should_compare_manifest(manifest: Dict, component: str, scenario: str) -> bool:
+def should_compare_manifest(
+    manifest: Dict,
+    component: str,
+    scenario: str,
+    is_kustomize_manifest: bool = True,
+) -> bool:
     """Select the resource subset owned by a comparison scenario."""
     kind = manifest.get("kind", "")
 
@@ -288,7 +293,7 @@ def should_compare_manifest(manifest: Dict, component: str, scenario: str) -> bo
     if component == "kubeflow-namespaces" and scenario == "platform-namespaces":
         return kind == "Namespace"
 
-    if component == "istio" and kind == "Namespace":
+    if component == "istio" and kind == "Namespace" and is_kustomize_manifest:
         return manifest.get("metadata", {}).get("name", "") != "istio-system"
 
     return True
@@ -378,7 +383,9 @@ def compare_manifests(
     helm_resources = {}
 
     for manifest in kustomize_manifests:
-        if not should_compare_manifest(manifest, component, scenario):
+        if not should_compare_manifest(
+            manifest, component, scenario, is_kustomize_manifest=True
+        ):
             continue
         normalized = normalize_manifest(
             manifest, component, normalize_kustomize_names=True
@@ -387,7 +394,9 @@ def compare_manifests(
         kustomize_resources[key] = normalized
 
     for manifest in helm_manifests:
-        if not should_compare_manifest(manifest, component, scenario):
+        if not should_compare_manifest(
+            manifest, component, scenario, is_kustomize_manifest=False
+        ):
             continue
         normalized = normalize_manifest(
             manifest,

--- a/tests/test_helm_kustomize_compare.py
+++ b/tests/test_helm_kustomize_compare.py
@@ -275,7 +275,7 @@ class OAuth2ProxyResourceKeyTest(unittest.TestCase):
 
 
 class IstioManifestSelectionTest(unittest.TestCase):
-    def test_foundation_owned_istio_system_namespace_is_excluded(self):
+    def test_only_kustomize_excludes_foundation_owned_istio_system_namespace(self):
         namespace = {
             "apiVersion": "v1",
             "kind": "Namespace",
@@ -287,6 +287,15 @@ class IstioManifestSelectionTest(unittest.TestCase):
                 namespace,
                 component="istio",
                 scenario="base",
+                is_kustomize_manifest=True,
+            )
+        )
+        self.assertTrue(
+            helm_kustomize_compare.should_compare_manifest(
+                namespace,
+                component="istio",
+                scenario="base",
+                is_kustomize_manifest=False,
             )
         )
 

--- a/tests/test_helm_synchronization_library.py
+++ b/tests/test_helm_synchronization_library.py
@@ -10,6 +10,12 @@ LIBRARY_PATH = REPOSITORY_ROOT / "scripts/library.sh"
 
 
 class HelmSynchronizationLibraryTest(unittest.TestCase):
+    def test_helpers_use_explicit_temporary_file_suffixes(self):
+        library_text = LIBRARY_PATH.read_text()
+
+        self.assertNotIn(".tmp.XXXXXX", library_text)
+        self.assertIn(".temporary.XXXXXX", library_text)
+
     def update_application_version(self, application_version, chart_text=None):
         if chart_text is None:
             chart_text = "apiVersion: v2\nappVersion: v1.0.0\n"
@@ -117,7 +123,7 @@ class HelmSynchronizationLibraryTest(unittest.TestCase):
                 text=True,
             )
             temporary_files = list(
-                Path(temporary_directory).glob("generated.yaml.tmp.*")
+                Path(temporary_directory).glob("generated.yaml.temporary.*")
             )
             return (
                 result,

--- a/tests/test_istio_helm_chart.py
+++ b/tests/test_istio_helm_chart.py
@@ -196,6 +196,21 @@ class IstioHelmChartTest(unittest.TestCase):
 
 
 class IstioWorkflowTest(unittest.TestCase):
+    def test_istio_job_persists_the_pinned_kustomize_directory(self):
+        workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+        unit_test_job = workflow["jobs"]["validate-istio-unit-tests"]
+        installation_step = next(
+            step
+            for step in unit_test_job["steps"]
+            if step.get("name") == "Install Kustomize"
+        )
+
+        self.assertIn("./tests/kustomize_install.sh", installation_step["run"])
+        self.assertIn(
+            'echo "/tmp/usr/local/bin" >> "$GITHUB_PATH"',
+            installation_step["run"],
+        )
+
     def test_istio_unit_tests_run_in_enforcing_job(self):
         workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
         unit_test_job = workflow["jobs"]["validate-istio-unit-tests"]


### PR DESCRIPTION
## Summary

- persist the pinned Kustomize installation directory for the enforcing Istio parity step
- exclude the foundation-owned `istio-system` namespace only from Kustomize input
- use explicit temporary-file suffixes in the synchronization library
- add focused regression coverage

Follow-up to the review findings on #3478 requested in https://github.com/kubeflow/community-distribution/pull/3478#issuecomment-5057237904.

## Validation

- `python3 -m unittest tests/test_istio_helm_chart.py tests/test_helm_kustomize_compare.py tests/test_helm_synchronization_library.py`
- `uvx --from black==26.5.1 black --check --diff ./common ./example ./tests`
- `bash -n scripts/library.sh scripts/synchronize-istio-manifests.sh`
- `yamllint .github/workflows/helm-kustomize-comparison.yml`
- `helm lint common/istio/helm`
- `./tests/helm_kustomize_compare_all.sh istio`
- `git diff origin/master...HEAD --check`