### PR TITLE
ci: set a job level timeout on the KinD based workflows

### DIFF
--- a/.github/workflows/dashboard_test.yaml
+++ b/.github/workflows/dashboard_test.yaml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   dashboard_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/dex_oauth2-proxy_test.yaml
+++ b/.github/workflows/dex_oauth2-proxy_test.yaml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   dex_oauth2-proxy_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/istio_validation.yaml
+++ b/.github/workflows/istio_validation.yaml
@@ -23,6 +23,7 @@ env:
 jobs:
   istio_validation:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       matrix:
         istio-mode: ['cni', 'insecure', 'ambient']

--- a/.github/workflows/katib_test.yaml
+++ b/.github/workflows/katib_test.yaml
@@ -24,6 +24,7 @@ env:
 jobs:
   katib_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/katib_test.yaml
+++ b/.github/workflows/katib_test.yaml
@@ -24,7 +24,7 @@ env:
 jobs:
   katib_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/manifests_example_test.yaml
+++ b/.github/workflows/manifests_example_test.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Test
     if: ${{ github.repository == 'kubeflow/community-distribution' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - name: Check out repo

--- a/.github/workflows/model_catalog_test.yaml
+++ b/.github/workflows/model_catalog_test.yaml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   model_catalog_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/model_registry_test.yaml
+++ b/.github/workflows/model_registry_test.yaml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   model_registry_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/notebooks_api_authorization_test.yaml
+++ b/.github/workflows/notebooks_api_authorization_test.yaml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   notebooks_api_authorization_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pipeline_run_from_notebook.yaml
+++ b/.github/workflows/pipeline_run_from_notebook.yaml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   pipeline_run_from_notebook:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pipeline_run_from_notebook.yaml
+++ b/.github/workflows/pipeline_run_from_notebook.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   pipeline_run_from_notebook:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trainer_test.yaml
+++ b/.github/workflows/trainer_test.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   trainer_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 25
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trainer_test.yaml
+++ b/.github/workflows/trainer_test.yaml
@@ -26,6 +26,7 @@ env:
 jobs:
   trainer_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/workspaces_deployment_test.yaml
+++ b/.github/workflows/workspaces_deployment_test.yaml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   workspaces_controller_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/workspaces_pipeline_run_test.yaml
+++ b/.github/workflows/workspaces_pipeline_run_test.yaml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   workspaces_pipeline_run_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary of Changes

Twenty three of the twenty nine jobs in this repository set no
`timeout-minutes` and inherit the GitHub default of 360 minutes. Twelve of those
provision a KinD cluster, so a single hung process occupies a runner for hours
before anything stops it.

This sets a job level timeout on those twelve. One line each, no other change.

## How the values were chosen

There is no written timeout convention in this repository, and the six existing
values were introduced without a recorded rationale, so this proposes one.

Durations were measured from the twenty most recent successful runs of each
workflow. The value is two and a half times the observed maximum, rounded up to
the nearest five minutes, with a floor of fifteen.

| Workflow | Job | median | max | value |
| --- | --- | --- | --- | --- |
| `dashboard_test.yaml` | `dashboard_test` | 3m | 4m | 15 |
| `manifests_example_test.yaml` | `manifests_example_test` | 2m | 6m | 15 |
| `dex_oauth2-proxy_test.yaml` | `dex_oauth2-proxy_test` | 5m | 7m | 20 |
| `workspaces_deployment_test.yaml` | `workspaces_controller_test` | 4m | 7m | 20 |
| `notebooks_api_authorization_test.yaml` | `notebooks_api_authorization_test` | 4m | 8m | 20 |
| `istio_validation.yaml` | `istio_validation` | 5m | 9m | 25 |
| `model_catalog_test.yaml` | `model_catalog_test` | 4m | 9m | 25 |
| `model_registry_test.yaml` | `model_registry_test` | 5m | 9m | 25 |
| `workspaces_pipeline_run_test.yaml` | `workspaces_pipeline_run_test` | 7m | 10m | 25 |
| `katib_test.yaml` | `katib_test` | 7m | 12m | 30 |
| `pipeline_run_from_notebook.yaml` | `pipeline_run_from_notebook` | 7m | 11m | 30 |
| `trainer_test.yaml` | `trainer_test` | 9m | 16m | 40 |

`istio_validation.yaml` runs a three leg matrix. A single job level key applies
to each leg independently, which is what is wanted.

## What is deliberately not changed

- Lightweight jobs (linting, formatting, stale bot, `osv-scanner`, welcome bot,
  Helm comparison unit tests) complete in seconds and are left alone.
- The six existing values are untouched. `full_kubeflow_integration_test` keeps
  its forty five minutes: across the last forty runs there were thirty six
  successes, three failures at 6, 38 and 39 minutes, and no cancelled runs, so
  the limit is not being reached.
- The step level `timeout-minutes: 5` on the diagnostics step is unchanged. It
  serves a different purpose, bounding a hung collection so the job can still
  report a genuine failure rather than being cancelled.

## Verification

- Every workflow file still parses.
- All eighteen KinD based jobs now report a job level timeout, and no
  lightweight job was modified.
- `pre-commit` passes, including `yamllint`.
- The diff is twelve files, twelve insertions, zero deletions.

## Related Issues

Closes https://github.com/kubeflow/community-distribution/issues/3565

Requested during review of
https://github.com/kubeflow/community-distribution/pull/3560 in
https://github.com/kubeflow/community-distribution/pull/3560#discussion_r3658033142
and
https://github.com/kubeflow/community-distribution/pull/3560#discussion_r3658030866

## Contributor Checklist

- [x] All commits are [signed off](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.